### PR TITLE
Introduce `sappho-source`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,8 +308,9 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "derive_more",
- "sappho-eval",
+ "sappho-interpreter",
  "sappho-parser",
+ "sappho-source",
 ]
 
 [[package]]
@@ -354,6 +355,7 @@ dependencies = [
  "pathutil",
  "sappho-eval",
  "sappho-parser",
+ "sappho-source",
 ]
 
 [[package]]
@@ -365,7 +367,15 @@ dependencies = [
  "include_dir",
  "sappho-ast",
  "sappho-identmap",
+ "sappho-source",
  "test-case",
+]
+
+[[package]]
+name = "sappho-source"
+version = "0.1.0"
+dependencies = [
+ "pathutil",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
   "integration-tests",
   "interpreter",
   "parser",
+  "source",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,8 +15,11 @@ features = [
   "cargo",
 ]
 
-[dependencies.sappho-eval]
-path = "../eval"
+[dependencies.sappho-interpreter]
+path = "../interpreter"
 
 [dependencies.sappho-parser]
 path = "../parser"
+
+[dependencies.sappho-source]
+path = "../source"

--- a/cli/src/cmds.rs
+++ b/cli/src/cmds.rs
@@ -1,16 +1,13 @@
 use crate::{Result, SourceOption};
 
-pub fn parse(srcopt: &SourceOption) -> Result<()> {
-    let source = srcopt.read()?;
-    let x = sappho_parser::parse(srcopt.path(), &source)?;
+pub fn parse(source: &SourceOption) -> Result<()> {
+    let x = sappho_parser::parse(source)?;
     println!("Parsed: {:#?}", x);
     Ok(())
 }
 
-pub fn eval(srcopt: &SourceOption) -> Result<()> {
-    let source = srcopt.read()?;
-    let ast = sappho_parser::parse(srcopt.path(), &source)?;
-    let x = sappho_eval::eval(ast)?;
+pub fn eval(source: &SourceOption) -> Result<()> {
+    let x = sappho_interpreter::interpret(source)?;
     println!("{:#?}", x);
     Ok(())
 }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,23 +1,2 @@
-use derive_more::From;
-use std::fmt;
-
-#[derive(Debug, From)]
-pub enum Error {
-    Std(std::io::Error),
-    Parse(sappho_parser::Errors),
-    Eval(sappho_eval::Error),
-}
-
-pub type Result<T> = std::result::Result<T, Error>;
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Error::*;
-
-        match self {
-            Std(e) => write!(f, "I/O error: {}", e),
-            Parse(e) => e.fmt(f),
-            Eval(e) => write!(f, "{:#?}", e),
-        }
-    }
-}
+pub type Error<'a> = sappho_interpreter::Error<'a>;
+pub type Result<'a, T> = sappho_interpreter::Result<'a, T>;

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -1,12 +1,9 @@
-use crate::{Options, Result};
+use crate::Options;
 
 pub fn run() {
-    if let Some(e) = run_result().err() {
+    let opt = Options::parse();
+    if let Some(e) = opt.run().err() {
         eprintln!("{}", e);
         std::process::exit(1);
     }
-}
-
-pub fn run_result() -> Result<()> {
-    Options::parse().run()
 }

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -1,6 +1,7 @@
 use crate::ValRef;
 use derive_more::From;
 use sappho_ast::Identifier;
+use std::fmt;
 
 #[derive(Debug, From)]
 pub enum Error {
@@ -9,3 +10,14 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match self {
+            Unbound(id) => write!(f, "unbound {:?}", id),
+            Uncallable(v) => write!(f, "not callable {:?}", v),
+        }
+    }
+}

--- a/eval/src/tests.rs
+++ b/eval/src/tests.rs
@@ -25,7 +25,7 @@ use test_case::test_case;
     ; "fn and apply"
 )]
 fn eval(src: &str) -> Value {
-    let ast = sappho_parser::parse(None, src).unwrap();
+    let ast = sappho_parser::parse(src).unwrap();
     let vref = crate::eval(ast).unwrap();
     std::rc::Rc::try_unwrap(vref).unwrap()
 }

--- a/integration-tests/src/testlogic.rs
+++ b/integration-tests/src/testlogic.rs
@@ -2,7 +2,7 @@ use sappho_interpreter::interpret;
 use std::path::PathBuf;
 
 pub fn test_eval(inpath: PathBuf, input: &str, expected: &str) {
-    let res = interpret(Some(inpath), input);
+    let res = interpret((inpath.as_path(), input));
     let actual = format!("{:#?}", res);
     assert_eq!(expected.trim_end(), &actual);
 }

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -14,3 +14,6 @@ path = "../eval"
 
 [dependencies.sappho-parser]
 path = "../parser"
+
+[dependencies.sappho-source]
+path = "../source"

--- a/interpreter/src/error.rs
+++ b/interpreter/src/error.rs
@@ -1,8 +1,23 @@
+use std::fmt;
+
 #[derive(Debug, derive_more::From)]
-pub enum Error {
-    Stdio(std::io::Error),
-    Parse(sappho_parser::Errors),
+pub enum Error<'a> {
+    LoadParse(sappho_parser::LoadParseError<'a>),
     Eval(sappho_eval::Error),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<'a, T> = std::result::Result<T, Error<'a>>;
+
+impl<'a> fmt::Display for Error<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match self {
+            LoadParse(e) => e.fmt(f),
+            Eval(e) => {
+                write!(f, "eval error: ")?;
+                e.fmt(f)
+            }
+        }
+    }
+}

--- a/interpreter/src/interpret.rs
+++ b/interpreter/src/interpret.rs
@@ -1,10 +1,13 @@
 use crate::Result;
 use sappho_eval::{eval, ValRef};
 use sappho_parser::parse;
-use std::path::PathBuf;
+use sappho_source::LoadSource;
 
-pub fn interpret(path: Option<PathBuf>, code: &str) -> Result<ValRef> {
-    let ast = parse(path, code)?;
+pub fn interpret<'a, S>(source: S) -> Result<'a, ValRef>
+where
+    S: LoadSource<'a>,
+{
+    let ast = parse(source)?;
     let val = eval(ast)?;
     Ok(val)
 }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,6 +15,9 @@ path = "../ast"
 [dependencies.sappho-identmap]
 path = "../identmap"
 
+[dependencies.sappho-source]
+path = "../source"
+
 [dev-dependencies]
 test-case = "2.0"
 include_dir = "0.7"

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -1,8 +1,10 @@
 mod bare;
 mod indent;
+mod load;
 mod set;
 mod sourced;
 
 pub use self::bare::{BareError, Label, Span};
+pub use self::load::LoadParseError;
 pub use self::set::{ErrorSet, Errors};
 pub use self::sourced::SourcedError;

--- a/parser/src/error/load.rs
+++ b/parser/src/error/load.rs
@@ -1,0 +1,25 @@
+use crate::error::Errors;
+use std::fmt;
+
+#[derive(Debug, derive_more::From)]
+pub enum LoadParseError<'a> {
+    Load(std::io::Error),
+    Parse(Errors<'a>),
+}
+
+impl<'a> fmt::Display for LoadParseError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use LoadParseError::*;
+
+        match self {
+            Load(e) => {
+                write!(f, "load error: ")?;
+                e.fmt(f)
+            }
+            Parse(e) => {
+                write!(f, "parse error: ")?;
+                e.fmt(f)
+            }
+        }
+    }
+}

--- a/parser/src/error/set.rs
+++ b/parser/src/error/set.rs
@@ -1,19 +1,18 @@
 use crate::error::{BareError, SourcedError};
-
+use sappho_source::Source;
 use std::fmt;
-use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct ErrorSet<E>(Vec<E>);
 
-pub type Errors = ErrorSet<SourcedError>;
+pub type Errors<'a> = ErrorSet<SourcedError<'a>>;
 
-impl Errors {
-    pub fn attach_source(path: Option<PathBuf>, src: &str, bares: Vec<BareError>) -> Self {
+impl<'a> Errors<'a> {
+    pub fn attach_source(source: Source<'a>, bares: Vec<BareError>) -> Self {
         ErrorSet(
             bares
                 .into_iter()
-                .map(|bare| SourcedError::new(path.clone(), src, bare))
+                .map(|bare| SourcedError::new(source.clone(), bare))
                 .collect(),
         )
     }

--- a/parser/src/error/sourced.rs
+++ b/parser/src/error/sourced.rs
@@ -21,7 +21,7 @@ impl<'a> fmt::Display for SourcedError<'a> {
         let (lix, lspan, lstr) = select_source(self.source.text(), self.bare.span());
         write!(
             f,
-            "Error from {}, line {}:\n{}|\n+-> Syntax error: {}\n",
+            "from {}, line {}:\n{}|\n+-> Syntax error: {}\n",
             self.source
                 .path()
                 .map(|p| format!("{:?}", p.display()))

--- a/parser/src/error/sourced.rs
+++ b/parser/src/error/sourced.rs
@@ -1,31 +1,29 @@
 use crate::error::{BareError, Span};
+use sappho_source::Source;
 use std::fmt;
-use std::path::PathBuf;
 
 #[derive(Debug)]
-pub struct SourcedError {
-    path: Option<PathBuf>,
-    source: String,
+pub struct SourcedError<'a> {
+    source: Source<'a>,
     bare: BareError,
 }
 
-impl SourcedError {
-    pub fn new(path: Option<PathBuf>, source: &str, bare: BareError) -> Self {
-        let source = source.to_string();
-        SourcedError { path, source, bare }
+impl<'a> SourcedError<'a> {
+    pub fn new(source: Source<'a>, bare: BareError) -> Self {
+        SourcedError { source, bare }
     }
 }
 
-impl fmt::Display for SourcedError {
+impl<'a> fmt::Display for SourcedError<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use crate::error::indent::indent;
 
-        let (lix, lspan, lstr) = select_source(&self.source, self.bare.span());
+        let (lix, lspan, lstr) = select_source(self.source.text(), self.bare.span());
         write!(
             f,
             "Error from {}, line {}:\n{}|\n+-> Syntax error: {}\n",
-            self.path
-                .as_ref()
+            self.source
+                .path()
                 .map(|p| format!("{:?}", p.display()))
                 .unwrap_or_else(|| "<string>".to_string()),
             lix + 1,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -6,16 +6,22 @@ mod listform;
 mod restrict;
 mod space;
 
-use std::path::PathBuf;
+use crate::error::Errors;
+use sappho_source::LoadSource;
 
-pub use self::error::Errors;
+pub use self::error::LoadParseError;
 
-pub fn parse(path: Option<PathBuf>, src: &str) -> Result<sappho_ast::PureExpr, Errors> {
+pub fn parse<'a, S>(sourceloader: S) -> Result<sappho_ast::PureExpr, LoadParseError<'a>>
+where
+    S: LoadSource<'a>,
+{
     use chumsky::Parser;
 
+    let source = sourceloader.load()?;
+
     self::expr::expression()
-        .parse(src.trim_end())
-        .map_err(|bares| Errors::attach_source(path, src, bares))
+        .parse(source.text().trim_end())
+        .map_err(|bares| LoadParseError::Parse(Errors::attach_source(source, bares)))
 }
 
 #[cfg(test)]

--- a/parser/src/tests/corpus/error.rs
+++ b/parser/src/tests/corpus/error.rs
@@ -15,7 +15,7 @@ pub enum Reason {
     UnexpectedFile,
     StrUtf8(std::str::Utf8Error),
     StringUtf8(std::string::FromUtf8Error),
-    Parse(crate::Errors),
+    Parse(crate::LoadParseError<'static>),
     InvalidParse(PureExpr),
     MismatchedOutput(Mismatch),
 }

--- a/parser/src/tests/corpus/negatives/bad-numlit/expected
+++ b/parser/src/tests/corpus/negatives/bad-numlit/expected
@@ -1,4 +1,4 @@
-Error from "negatives/bad-numlit/input", line 1:
+parse error: from "negatives/bad-numlit/input", line 1:
 | 4ty-two
 |  ^
 |

--- a/parser/src/tests/corpus/negatives/bad-parens/expected
+++ b/parser/src/tests/corpus/negatives/bad-parens/expected
@@ -1,4 +1,4 @@
-Error from "negatives/bad-parens/input", line 1:
+parse error: from "negatives/bad-parens/input", line 1:
 | [(]
 |   ^
 |

--- a/parser/src/tests/corpus/negatives/bare-evocation/expected
+++ b/parser/src/tests/corpus/negatives/bare-evocation/expected
@@ -1,4 +1,4 @@
-Error from "negatives/bare-evocation/input", line 1:
+parse error: from "negatives/bare-evocation/input", line 1:
 | !x
 | ^^
 |

--- a/parser/src/tests/corpus/negatives/bare-inquiry/expected
+++ b/parser/src/tests/corpus/negatives/bare-inquiry/expected
@@ -1,4 +1,4 @@
-Error from "negatives/bare-inquiry/input", line 1:
+parse error: from "negatives/bare-inquiry/input", line 1:
 | $x
 | ^^
 |

--- a/parser/src/tests/corpus/negatives/duplicate-attrs/expected
+++ b/parser/src/tests/corpus/negatives/duplicate-attrs/expected
@@ -1,4 +1,4 @@
-Error from "negatives/duplicate-attrs/input", line 1:
+parse error: from "negatives/duplicate-attrs/input", line 1:
 | {
 | ^
 |

--- a/parser/src/tests/corpus/negatives/evocation-in-query/expected
+++ b/parser/src/tests/corpus/negatives/evocation-in-query/expected
@@ -1,4 +1,4 @@
-Error from "negatives/evocation-in-query/input", line 1:
+parse error: from "negatives/evocation-in-query/input", line 1:
 | query !x
 |       ^^
 |

--- a/parser/src/tests/corpus/negatives/inquiry-space/expected
+++ b/parser/src/tests/corpus/negatives/inquiry-space/expected
@@ -1,4 +1,4 @@
-Error from "negatives/inquiry-space/input", line 1:
+parse error: from "negatives/inquiry-space/input", line 1:
 | query $ x
 |        ^
 |

--- a/parser/src/tests/corpus/negatives/invalid-let-syntax/expected
+++ b/parser/src/tests/corpus/negatives/invalid-let-syntax/expected
@@ -1,4 +1,4 @@
-Error from "negatives/invalid-let-syntax/input", line 1:
+parse error: from "negatives/invalid-let-syntax/input", line 1:
 | let {
 |     ^
 |

--- a/parser/src/tests/corpus/negatives/num-letter/expected
+++ b/parser/src/tests/corpus/negatives/num-letter/expected
@@ -1,4 +1,4 @@
-Error from "negatives/num-letter/input", line 1:
+parse error: from "negatives/num-letter/input", line 1:
 | 7x
 |  ^
 |

--- a/parser/src/tests/corpus/negatives/open-square-bracket/expected
+++ b/parser/src/tests/corpus/negatives/open-square-bracket/expected
@@ -1,4 +1,4 @@
-Error from "negatives/open-square-bracket/input", line 1:
+parse error: from "negatives/open-square-bracket/input", line 1:
 | [
 |  ^
 |

--- a/parser/src/tests/unit.rs
+++ b/parser/src/tests/unit.rs
@@ -157,7 +157,7 @@ use test_case::test_case;
     ; "object fn and query"
 )]
 fn positive(input: &str) -> sappho_ast::PureExpr {
-    match crate::parse(None, input) {
+    match crate::parse(input) {
         Ok(x) => x,
         Err(e) => {
             eprintln!("{}", e);

--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sappho-source"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+pathutil = "0.1.3"

--- a/source/src/lib.rs
+++ b/source/src/lib.rs
@@ -1,0 +1,7 @@
+//! A crate for loading source code while tracking its provenance.
+
+mod load;
+mod source;
+
+pub use self::load::LoadSource;
+pub use self::source::Source;

--- a/source/src/load.rs
+++ b/source/src/load.rs
@@ -24,3 +24,10 @@ impl<'a> LoadSource<'a> for &'a Path {
         Source::load_path(self)
     }
 }
+
+impl<'a> LoadSource<'a> for (&'a Path, &'a str) {
+    fn load(self) -> Result<Source<'a>> {
+        let (path, text) = self;
+        Ok(Source::wrap(path, text))
+    }
+}

--- a/source/src/load.rs
+++ b/source/src/load.rs
@@ -1,0 +1,26 @@
+use crate::Source;
+use std::io::Result;
+use std::path::Path;
+
+/// Load a [Source] via [std::io::Result]. Impls are provided for [String], [str], and [Path].
+pub trait LoadSource<'a> {
+    fn load(self) -> Result<Source<'a>>;
+}
+
+impl<'a> LoadSource<'a> for &'a str {
+    fn load(self) -> Result<Source<'a>> {
+        Ok(Source::wrap_string(self))
+    }
+}
+
+impl<'a> LoadSource<'a> for String {
+    fn load(self) -> Result<Source<'a>> {
+        Ok(Source::wrap_string(self))
+    }
+}
+
+impl<'a> LoadSource<'a> for &'a Path {
+    fn load(self) -> Result<Source<'a>> {
+        Source::load_path(self)
+    }
+}

--- a/source/src/source.rs
+++ b/source/src/source.rs
@@ -41,4 +41,11 @@ impl<'a> Source<'a> {
     pub fn text(&self) -> &str {
         self.cowtext.as_ref()
     }
+
+    pub(crate) fn wrap(path: &'a Path, text: &'a str) -> Self {
+        Source {
+            optpath: Some(path),
+            cowtext: Cow::from(text),
+        }
+    }
 }

--- a/source/src/source.rs
+++ b/source/src/source.rs
@@ -1,0 +1,43 @@
+use std::borrow::Cow;
+use std::io::Result;
+use std::path::Path;
+
+/// A `Source` refers to the textual source code and tracks the [Path] it came from (if any).
+pub struct Source<'a> {
+    optpath: Option<&'a Path>,
+    cowtext: Cow<'a, str>,
+}
+
+impl<'a> Source<'a> {
+    /// Load source from a [Path].
+    pub fn load_path(path: &Path) -> Result<Source> {
+        use pathutil::PathExt;
+
+        let text = path.pe_read_to_string()?;
+        Ok(Source {
+            optpath: Some(path),
+            cowtext: Cow::from(text),
+        })
+    }
+
+    /// Wrap a source string.
+    pub fn wrap_string<S>(text: S) -> Source<'a>
+    where
+        Cow<'a, str>: From<S>,
+    {
+        Source {
+            optpath: None,
+            cowtext: Cow::from(text),
+        }
+    }
+
+    /// The [Path] this source was loaded from, if any.
+    pub fn path(&self) -> Option<&Path> {
+        self.optpath
+    }
+
+    /// The source code text of this source.
+    pub fn text(&self) -> &str {
+        self.cowtext.as_ref()
+    }
+}

--- a/source/src/source.rs
+++ b/source/src/source.rs
@@ -3,6 +3,7 @@ use std::io::Result;
 use std::path::Path;
 
 /// A `Source` refers to the textual source code and tracks the [Path] it came from (if any).
+#[derive(Clone, Debug)]
 pub struct Source<'a> {
     optpath: Option<&'a Path>,
     cowtext: Cow<'a, str>,


### PR DESCRIPTION
This PR also integrates `sappho-interpreter` into the cli and tests. Together `sappho-interpreter` and `sappho-source` streamline read/parse/eval call sites and error types.

This PR also tweaks error displays.