### PR TITLE
Value coercion.

### DIFF
--- a/eval/src/coerce.rs
+++ b/eval/src/coerce.rs
@@ -1,0 +1,5 @@
+use crate::Value;
+
+pub trait Coerce {
+    fn coerce_from_value(v: &Value) -> Option<&Self>;
+}

--- a/eval/src/coerce.rs
+++ b/eval/src/coerce.rs
@@ -1,5 +1,35 @@
-use crate::Value;
+use crate::{Attrs, Func, Object, Value};
 
 pub trait Coerce {
     fn coerce_from_value(v: &Value) -> Option<&Self>;
+}
+
+impl Coerce for f64 {
+    fn coerce_from_value(v: &Value) -> Option<&f64> {
+        match v {
+            Value::Num(x) => Some(x),
+            _ => None,
+        }
+    }
+}
+
+impl Coerce for Object {
+    fn coerce_from_value(v: &Value) -> Option<&Object> {
+        match v {
+            Value::Object(x) => Some(x),
+            _ => None,
+        }
+    }
+}
+
+impl Coerce for Func {
+    fn coerce_from_value(v: &Value) -> Option<&Func> {
+        Object::coerce_from_value(v).and_then(|obj| obj.func())
+    }
+}
+
+impl Coerce for Attrs {
+    fn coerce_from_value(v: &Value) -> Option<&Attrs> {
+        Object::coerce_from_value(v).map(|obj| obj.attrs())
+    }
 }

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -6,7 +6,6 @@ use std::fmt;
 #[derive(Debug, From)]
 pub enum Error {
     Unbound(Identifier),
-    Uncallable(ValRef),
     MissingAttr(ValRef, Identifier),
     Mismatch(ValRef, Vec<Pattern>),
     CoercionFailure(ValRef, &'static str),
@@ -20,7 +19,6 @@ impl fmt::Display for Error {
 
         match self {
             Unbound(id) => write!(f, "unbound {:?}", id),
-            Uncallable(v) => write!(f, "not callable {}", v),
             MissingAttr(v, name) => write!(f, "missing attr {}.{}", v, name),
             Mismatch(v, pats) => {
                 write!(

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     Uncallable(ValRef),
     MissingAttr(ValRef, Identifier),
     Mismatch(ValRef, Vec<Pattern>),
+    CoercionFailure(ValRef, &'static str),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -32,6 +33,7 @@ impl fmt::Display for Error {
                         .join(", ")
                 )
             }
+            CoercionFailure(v, typename) => write!(f, "Could not coerce {} to {}", v, typename),
         }
     }
 }

--- a/eval/src/eval.rs
+++ b/eval/src/eval.rs
@@ -4,7 +4,8 @@ mod object;
 mod recursive;
 mod traits;
 
-use self::traits::{Eval, EvalV};
+pub(crate) use self::traits::Eval;
+use self::traits::EvalV;
 use crate::scope::ScopeRef;
 use crate::{Result, ValRef};
 use sappho_east::PureExpr;

--- a/eval/src/eval/recursive.rs
+++ b/eval/src/eval/recursive.rs
@@ -87,20 +87,15 @@ where
     FX: Eval,
 {
     fn eval(&self, scope: ScopeRef) -> Result<ValRef> {
+        use crate::Attrs;
         use crate::Error::MissingAttr;
-        use std::borrow::Borrow;
 
         let LookupExpr { target, attr } = self;
         let tval = target.eval(scope)?;
-        match tval.borrow() {
-            Value::Object(obj) => {
-                if let Some(v) = obj.attrs().get(attr) {
-                    Ok(v.clone())
-                } else {
-                    Err(MissingAttr(tval, attr.clone()))
-                }
-            }
-            _ => Err(MissingAttr(tval, attr.clone())),
-        }
+        let attrs: &Attrs = tval.coerce()?;
+        attrs
+            .get(attr)
+            .cloned()
+            .ok_or_else(|| MissingAttr(tval, attr.clone()))
     }
 }

--- a/eval/src/eval/recursive.rs
+++ b/eval/src/eval/recursive.rs
@@ -80,8 +80,8 @@ where
         let aval = argument.eval(scope)?;
         match tval.borrow() {
             Value::Object(obj) => {
-                if let Some(fnbox) = obj.func() {
-                    fnbox(aval)
+                if let Some(func) = obj.func() {
+                    func.apply(&aval)
                 } else {
                     Err(Uncallable(tval))
                 }

--- a/eval/src/eval/recursive.rs
+++ b/eval/src/eval/recursive.rs
@@ -73,20 +73,16 @@ where
 {
     fn eval(&self, scope: ScopeRef) -> Result<ValRef> {
         use crate::Error::Uncallable;
-        use std::borrow::Borrow;
+        use crate::Object;
 
         let ApplicationExpr { target, argument } = self;
         let tval = target.eval(scope.clone())?;
         let aval = argument.eval(scope)?;
-        match tval.borrow() {
-            Value::Object(obj) => {
-                if let Some(func) = obj.func() {
-                    func.apply(&aval)
-                } else {
-                    Err(Uncallable(tval))
-                }
-            }
-            _ => Err(Uncallable(tval)),
+        let obj: &Object = tval.coerce()?;
+        if let Some(func) = obj.func() {
+            func.apply(&aval)
+        } else {
+            Err(Uncallable(tval))
         }
     }
 }

--- a/eval/src/eval/recursive.rs
+++ b/eval/src/eval/recursive.rs
@@ -72,18 +72,13 @@ where
     FX: Eval,
 {
     fn eval(&self, scope: ScopeRef) -> Result<ValRef> {
-        use crate::Error::Uncallable;
-        use crate::Object;
+        use crate::Func;
 
         let ApplicationExpr { target, argument } = self;
         let tval = target.eval(scope.clone())?;
         let aval = argument.eval(scope)?;
-        let obj: &Object = tval.coerce()?;
-        if let Some(func) = obj.func() {
-            func.apply(&aval)
-        } else {
-            Err(Uncallable(tval))
-        }
+        let func: &Func = tval.coerce()?;
+        func.apply(&aval)
     }
 }
 

--- a/eval/src/eval/traits.rs
+++ b/eval/src/eval/traits.rs
@@ -1,11 +1,11 @@
 use crate::scope::ScopeRef;
 use crate::{Result, ValRef, Value};
 
-pub(super) trait Eval {
+pub(crate) trait Eval {
     fn eval(&self, scope: ScopeRef) -> Result<ValRef>;
 }
 
-pub(super) trait EvalV {
+pub(crate) trait EvalV {
     fn eval_val(&self, scope: ScopeRef) -> Result<Value>;
 }
 

--- a/eval/src/func.rs
+++ b/eval/src/func.rs
@@ -1,0 +1,26 @@
+use crate::eval::Eval;
+use crate::scope::ScopeRef;
+use crate::{Result, ValRef};
+use sappho_east::{FuncClause, Pattern, PureExpr};
+use std::rc::Rc;
+
+pub struct Func {
+    binding: Pattern,
+    body: Rc<PureExpr>,
+    defscope: ScopeRef,
+}
+
+impl Func {
+    pub(crate) fn new(fc: &FuncClause, defscope: ScopeRef) -> Self {
+        Func {
+            binding: fc.binding.clone(),
+            body: fc.body.clone(),
+            defscope,
+        }
+    }
+
+    pub fn apply(&self, arg: &ValRef) -> Result<ValRef> {
+        let callscope = self.defscope.extend(&self.binding, arg.clone());
+        self.body.eval(callscope)
+    }
+}

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -1,8 +1,10 @@
 mod bind;
 mod error;
 mod eval;
+mod func;
 mod list;
 mod object;
+mod query;
 mod scope;
 mod valref;
 mod value;
@@ -10,8 +12,10 @@ mod value;
 pub(crate) use self::bind::bind;
 pub use self::error::{Error, Result};
 pub use self::eval::eval;
+pub use self::func::Func;
 pub use self::list::List;
 pub use self::object::Object;
+pub use self::query::Query;
 pub use self::valref::ValRef;
 pub use self::value::Value;
 

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -1,4 +1,5 @@
 mod bind;
+mod coerce;
 mod error;
 mod eval;
 mod func;
@@ -10,6 +11,7 @@ mod valref;
 mod value;
 
 pub(crate) use self::bind::bind;
+pub use self::coerce::Coerce;
 pub use self::error::{Error, Result};
 pub use self::eval::eval;
 pub use self::func::Func;

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -4,6 +4,7 @@ mod eval;
 mod list;
 mod object;
 mod scope;
+mod valref;
 mod value;
 
 pub(crate) use self::bind::bind;
@@ -11,7 +12,8 @@ pub use self::error::{Error, Result};
 pub use self::eval::eval;
 pub use self::list::List;
 pub use self::object::Object;
-pub use self::value::{ValRef, Value};
+pub use self::valref::ValRef;
+pub use self::value::Value;
 
 #[cfg(test)]
 mod tests;

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -16,6 +16,7 @@ pub use self::error::{Error, Result};
 pub use self::eval::eval;
 pub use self::func::Func;
 pub use self::list::List;
+pub(crate) use self::object::Attrs;
 pub use self::object::Object;
 pub use self::query::Query;
 pub use self::valref::ValRef;

--- a/eval/src/object.rs
+++ b/eval/src/object.rs
@@ -3,11 +3,12 @@ use sappho_identmap::IdentMap;
 use std::fmt;
 
 pub struct Object(Inner);
-
 type Inner = sappho_object::Object<Func, Query, ValRef>;
 
+pub(crate) type Attrs = IdentMap<ValRef>;
+
 impl Object {
-    pub fn new(func: Option<Func>, query: Option<Query>, attrs: IdentMap<ValRef>) -> Self {
+    pub fn new(func: Option<Func>, query: Option<Query>, attrs: Attrs) -> Self {
         Object(Inner::new(func, query, attrs))
     }
 }

--- a/eval/src/object.rs
+++ b/eval/src/object.rs
@@ -1,13 +1,13 @@
-use crate::{Result, ValRef};
+use crate::{Func, Query, ValRef};
 use sappho_identmap::IdentMap;
 use std::fmt;
 
 pub struct Object(Inner);
 
-type Inner = sappho_object::Object<FuncVal, QueryVal, ValRef>;
+type Inner = sappho_object::Object<Func, Query, ValRef>;
 
 impl Object {
-    pub fn new(func: Option<FuncVal>, query: Option<QueryVal>, attrs: IdentMap<ValRef>) -> Self {
+    pub fn new(func: Option<Func>, query: Option<Query>, attrs: IdentMap<ValRef>) -> Self {
         Object(Inner::new(func, query, attrs))
     }
 }
@@ -19,9 +19,6 @@ impl std::ops::Deref for Object {
         &self.0
     }
 }
-
-pub type FuncVal = Box<dyn Fn(ValRef) -> Result<ValRef>>;
-pub type QueryVal = Box<dyn Fn() -> Result<ValRef>>;
 
 impl fmt::Display for Object {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/eval/src/query.rs
+++ b/eval/src/query.rs
@@ -1,0 +1,23 @@
+use crate::eval::Eval;
+use crate::scope::ScopeRef;
+use crate::{Result, ValRef};
+use sappho_east::{QueryClause, QueryExpr};
+use std::rc::Rc;
+
+pub struct Query {
+    body: Rc<QueryExpr>,
+    defscope: ScopeRef,
+}
+
+impl Query {
+    pub(crate) fn new(qc: &QueryClause, defscope: ScopeRef) -> Self {
+        Query {
+            body: qc.body.clone(),
+            defscope,
+        }
+    }
+
+    pub fn query(&self) -> Result<ValRef> {
+        self.body.eval(self.defscope.clone())
+    }
+}

--- a/eval/src/tests.rs
+++ b/eval/src/tests.rs
@@ -27,5 +27,5 @@ use test_case::test_case;
 fn eval(src: &str) -> Value {
     let ast = sappho_parser::parse(src).unwrap();
     let vref = crate::eval(ast).unwrap();
-    std::rc::Rc::try_unwrap(vref).unwrap()
+    vref.unwrap()
 }

--- a/eval/src/valref.rs
+++ b/eval/src/valref.rs
@@ -1,0 +1,46 @@
+use crate::Value;
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
+use std::rc::Rc;
+
+#[derive(Clone, Debug)]
+pub struct ValRef(Rc<Value>);
+
+impl Deref for ValRef {
+    type Target = Value;
+
+    fn deref(&self) -> &Value {
+        self.0.deref()
+    }
+}
+
+impl Borrow<Value> for ValRef {
+    fn borrow(&self) -> &Value {
+        self.0.borrow()
+    }
+}
+
+impl<T> From<T> for ValRef
+where
+    Value: From<T>,
+{
+    fn from(v: T) -> Self {
+        ValRef(Rc::new(Value::from(v)))
+    }
+}
+
+impl fmt::Display for ValRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // BUG: Why doesn't `Deref` automatically enable `Display`?
+        self.deref().fmt(f)
+    }
+}
+
+#[cfg(test)]
+impl ValRef {
+    /// If Self is the only holder of the value, return it, otherwise panic.
+    pub fn unwrap(self) -> Value {
+        Rc::try_unwrap(self.0).unwrap()
+    }
+}

--- a/eval/src/valref.rs
+++ b/eval/src/valref.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::{Coerce, Result, Value};
 use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Deref;
@@ -6,6 +6,18 @@ use std::rc::Rc;
 
 #[derive(Clone, Debug)]
 pub struct ValRef(Rc<Value>);
+
+impl ValRef {
+    pub fn coerce<T>(&self) -> Result<&T>
+    where
+        T: Coerce,
+    {
+        use crate::Error::CoercionFailure;
+
+        T::coerce_from_value(&self.0)
+            .ok_or_else(|| CoercionFailure(self.clone(), std::any::type_name::<Self>()))
+    }
+}
 
 impl Deref for ValRef {
     type Target = Value;

--- a/eval/src/value.rs
+++ b/eval/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{Attrs, Coerce, Func, List, Object};
+use crate::{List, Object};
 use derive_more::From;
 use std::fmt;
 
@@ -8,40 +8,11 @@ pub enum Value {
     List(List),
     Object(Object),
 }
-use Value::*;
-
-impl Coerce for f64 {
-    fn coerce_from_value(v: &Value) -> Option<&f64> {
-        match v {
-            Num(x) => Some(x),
-            _ => None,
-        }
-    }
-}
-
-impl Coerce for Object {
-    fn coerce_from_value(v: &Value) -> Option<&Object> {
-        match v {
-            Object(x) => Some(x),
-            _ => None,
-        }
-    }
-}
-
-impl Coerce for Func {
-    fn coerce_from_value(v: &Value) -> Option<&Func> {
-        Object::coerce_from_value(v).and_then(|obj| obj.func())
-    }
-}
-
-impl Coerce for Attrs {
-    fn coerce_from_value(v: &Value) -> Option<&Attrs> {
-        Object::coerce_from_value(v).map(|obj| obj.attrs())
-    }
-}
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Value::*;
+
         match self {
             Num(x) => x.fmt(f),
             List(x) => x.fmt(f),

--- a/eval/src/value.rs
+++ b/eval/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{Coerce, Func, List, Object};
+use crate::{Attrs, Coerce, Func, List, Object};
 use derive_more::From;
 use std::fmt;
 
@@ -31,6 +31,12 @@ impl Coerce for Object {
 impl Coerce for Func {
     fn coerce_from_value(v: &Value) -> Option<&Func> {
         Object::coerce_from_value(v).and_then(|obj| obj.func())
+    }
+}
+
+impl Coerce for Attrs {
+    fn coerce_from_value(v: &Value) -> Option<&Attrs> {
+        Object::coerce_from_value(v).map(|obj| obj.attrs())
     }
 }
 

--- a/eval/src/value.rs
+++ b/eval/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{List, Object};
+use crate::{Coerce, List, Object};
 use derive_more::From;
 use std::fmt;
 
@@ -8,11 +8,28 @@ pub enum Value {
     List(List),
     Object(Object),
 }
+use Value::*;
+
+impl Coerce for f64 {
+    fn coerce_from_value(v: &Value) -> Option<&f64> {
+        match v {
+            Num(x) => Some(x),
+            _ => None,
+        }
+    }
+}
+
+impl Coerce for Object {
+    fn coerce_from_value(v: &Value) -> Option<&Object> {
+        match v {
+            Object(x) => Some(x),
+            _ => None,
+        }
+    }
+}
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Value::*;
-
         match self {
             Num(x) => x.fmt(f),
             List(x) => x.fmt(f),

--- a/eval/src/value.rs
+++ b/eval/src/value.rs
@@ -1,9 +1,6 @@
 use crate::{List, Object};
 use derive_more::From;
 use std::fmt;
-use std::rc::Rc;
-
-pub type ValRef = Rc<Value>;
 
 #[derive(Debug, From)]
 pub enum Value {

--- a/eval/src/value.rs
+++ b/eval/src/value.rs
@@ -1,4 +1,4 @@
-use crate::{Coerce, List, Object};
+use crate::{Coerce, Func, List, Object};
 use derive_more::From;
 use std::fmt;
 
@@ -25,6 +25,12 @@ impl Coerce for Object {
             Object(x) => Some(x),
             _ => None,
         }
+    }
+}
+
+impl Coerce for Func {
+    fn coerce_from_value(v: &Value) -> Option<&Func> {
+        Object::coerce_from_value(v).and_then(|obj| obj.func())
     }
 }
 


### PR DESCRIPTION
Intoduce a `Coerce` trait within `sappho-eval` to streamline call-sites that require a specific type of value. This PR also changes func/query values from `Box<dyn fn…>` to concrete types that hold the source expressions and definition scopes.