### PR TITLE
Introduce `GenThunk` abstraction providing an interface between `sappho-value` and `sappho-eval`.

### DIFF
--- a/eval/src/expr/application.rs
+++ b/eval/src/expr/application.rs
@@ -7,13 +7,13 @@ where
     FX: Eval,
 {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
+        use crate::EvalThunk;
         use sappho_value::Func;
 
         let ApplicationExpr { target, argument } = self;
         let tval = target.eval(scope)?;
         let aval = argument.eval(scope)?;
         let func: &Func = tval.coerce()?;
-        let (expr, boundscope) = func.bind_arg(&aval);
-        expr.eval(&boundscope)
+        func.bind_arg(&aval).eval_thunk()
     }
 }

--- a/eval/src/expr/effects.rs
+++ b/eval/src/expr/effects.rs
@@ -11,7 +11,14 @@ impl Eval for PureEffects {
 impl Eval for QueryEffects {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
         match self {
-            QueryEffects::Inquire(qexpr) => qexpr.eval(scope),
+            QueryEffects::Inquire(qexpr) => {
+                use crate::EvalThunk;
+                use sappho_value::Query;
+
+                let v = qexpr.eval(scope)?;
+                let q: &Query = v.coerce()?;
+                q.as_thunk().eval_thunk()
+            }
         }
     }
 }

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -6,6 +6,7 @@ mod bind;
 mod error;
 mod eval;
 mod expr;
+mod thunk;
 mod traits;
 
 pub use self::error::{Error, Result};
@@ -15,4 +16,4 @@ pub use self::eval::eval;
 pub use sappho_value::ValRef;
 
 pub(crate) use self::bind::bind;
-pub(crate) use self::traits::{Eval, EvalV};
+pub(crate) use self::traits::{Eval, EvalThunk, EvalV};

--- a/eval/src/thunk.rs
+++ b/eval/src/thunk.rs
@@ -1,0 +1,12 @@
+use crate::{Eval, EvalThunk, Result};
+use sappho_value::{GenThunk, ValRef};
+
+impl<'a, FX> EvalThunk for GenThunk<'a, FX>
+where
+    FX: Eval,
+{
+    fn eval_thunk(&self) -> Result<ValRef> {
+        let (expr, defscope) = self.peek();
+        expr.eval(defscope)
+    }
+}

--- a/eval/src/traits.rs
+++ b/eval/src/traits.rs
@@ -9,6 +9,10 @@ pub(crate) trait EvalV {
     fn eval_val(&self, scope: &ScopeRef) -> Result<Value>;
 }
 
+pub(crate) trait EvalThunk {
+    fn eval_thunk(&self) -> Result<ValRef>;
+}
+
 impl<T> Eval for T
 where
     T: EvalV,

--- a/value/src/coerce.rs
+++ b/value/src/coerce.rs
@@ -1,6 +1,6 @@
 mod failure;
 
-use crate::{Attrs, Func, Object, Value};
+use crate::{Attrs, Func, Object, Query, Value};
 
 pub use self::failure::CoercionFailure;
 
@@ -29,6 +29,12 @@ impl Coerce for Object {
 impl Coerce for Func {
     fn coerce_from_value(v: &Value) -> Option<&Func> {
         Object::coerce_from_value(v).and_then(|obj| obj.func())
+    }
+}
+
+impl Coerce for Query {
+    fn coerce_from_value(v: &Value) -> Option<&Query> {
+        Object::coerce_from_value(v).and_then(|obj| obj.query())
     }
 }
 

--- a/value/src/func.rs
+++ b/value/src/func.rs
@@ -1,6 +1,5 @@
-use crate::ScopeRef;
-use crate::ValRef;
-use sappho_east::{FuncClause, Pattern, PureExpr};
+use crate::{GenThunk, ScopeRef, ValRef};
+use sappho_east::{FuncClause, Pattern, PureEffects, PureExpr};
 use std::rc::Rc;
 
 pub struct Func {
@@ -18,9 +17,8 @@ impl Func {
         }
     }
 
-    // FIXME: introduce generic `Thunk` for eval.
-    pub fn bind_arg(&self, arg: &ValRef) -> (&PureExpr, ScopeRef) {
+    pub fn bind_arg(&self, arg: &ValRef) -> GenThunk<PureEffects> {
         let callscope = self.defscope.extend(&self.binding, arg.clone());
-        (&self.body, callscope)
+        GenThunk::new(&self.body, callscope)
     }
 }

--- a/value/src/lib.rs
+++ b/value/src/lib.rs
@@ -4,6 +4,7 @@ mod list;
 mod object;
 mod query;
 mod scope;
+mod thunk;
 mod valref;
 mod value;
 
@@ -13,5 +14,6 @@ pub use self::list::List;
 pub use self::object::{Attrs, Object};
 pub use self::query::Query;
 pub use self::scope::{Scope, ScopeRef, Unbound};
+pub use self::thunk::GenThunk;
 pub use self::valref::ValRef;
 pub use self::value::Value;

--- a/value/src/query.rs
+++ b/value/src/query.rs
@@ -1,5 +1,5 @@
-use crate::ScopeRef;
-use sappho_east::{QueryClause, QueryExpr};
+use crate::{GenThunk, ScopeRef};
+use sappho_east::{QueryClause, QueryEffects, QueryExpr};
 use std::rc::Rc;
 
 pub struct Query {
@@ -15,8 +15,7 @@ impl Query {
         }
     }
 
-    // FIXME: introduce generic `Thunk` for eval.
-    pub fn peek(&self) -> (&QueryExpr, &ScopeRef) {
-        (&self.body, &self.defscope)
+    pub fn as_thunk(&self) -> GenThunk<QueryEffects> {
+        GenThunk::new(&self.body, self.defscope.clone())
     }
 }

--- a/value/src/thunk.rs
+++ b/value/src/thunk.rs
@@ -1,0 +1,18 @@
+use crate::ScopeRef;
+use sappho_east::GenExpr;
+use std::rc::Rc;
+
+pub struct GenThunk<'a, Effects> {
+    expr: &'a Rc<GenExpr<Effects>>,
+    scope: ScopeRef,
+}
+
+impl<'a, FX> GenThunk<'a, FX> {
+    pub fn new(expr: &'a Rc<GenExpr<FX>>, scope: ScopeRef) -> Self {
+        GenThunk { scope, expr }
+    }
+
+    pub fn peek(&self) -> (&'a Rc<GenExpr<FX>>, &ScopeRef) {
+        (self.expr, &self.scope)
+    }
+}

--- a/value/src/thunk.rs
+++ b/value/src/thunk.rs
@@ -2,6 +2,21 @@ use crate::ScopeRef;
 use sappho_east::GenExpr;
 use std::rc::Rc;
 
+/// Bind a source expression to the runtime scope in which it appears for later evaluation.
+///
+/// # Query Example:
+///
+/// ```ignore
+/// query (
+///     let q = query 42;
+///     let r = query $q;
+///     $r
+/// )
+/// ```
+///
+/// When the value of `r` is evaluated a thunk captures the expression `$q` as well as the scope
+/// containing `q`. When `$r` is evaluated, the thunk of the `r` query is evaluated with it's
+/// definition scope.
 pub struct GenThunk<'a, Effects> {
     expr: &'a Rc<GenExpr<Effects>>,
     scope: ScopeRef,


### PR DESCRIPTION
Closes #40.