### PR TITLE
Rename `ListForm` → `ListExpr` for consistency.

### DIFF
--- a/ast/src/expr.rs
+++ b/ast/src/expr.rs
@@ -4,7 +4,7 @@ use crate::{
     ApplicationExpr, FuncDef, Identifier, LetExpr, Literal, LookupExpr, MatchExpr, ObjectDef,
     QueryDef,
 };
-use sappho_gast::ListForm;
+use sappho_gast::ListExpr;
 use std::fmt;
 
 /// The general top-level expression for all effects.
@@ -15,7 +15,7 @@ pub enum GenExpr<Effects> {
     Func(FuncDef),
     Query(QueryDef),
     Object(ObjectDef),
-    List(ListForm<GenExpr<Effects>>),
+    List(ListExpr<GenExpr<Effects>>),
     Let(LetExpr<Effects>),
     Match(MatchExpr<Effects>),
     Application(ApplicationExpr<Effects>),

--- a/east/src/expr.rs
+++ b/east/src/expr.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ApplicationExpr, AstFxFor, FromFx, Identifier, LetExpr, ListForm, Literal, LookupExpr,
+    ApplicationExpr, AstFxFor, FromFx, Identifier, LetExpr, ListExpr, Literal, LookupExpr,
     MatchExpr, ObjectDef,
 };
 use sappho_ast as ast;
@@ -10,7 +10,7 @@ pub enum GenExpr<Effects> {
     Lit(Literal),
     Ref(Identifier),
     Object(ObjectDef),
-    List(ListForm<GenExpr<Effects>>),
+    List(ListExpr<GenExpr<Effects>>),
     Let(LetExpr<Effects>),
     Match(MatchExpr<Effects>),
     Application(ApplicationExpr<Effects>),

--- a/east/src/lib.rs
+++ b/east/src/lib.rs
@@ -3,7 +3,7 @@
 mod effects;
 mod expr;
 
-pub use sappho_gast::{Identifier, ListForm, Literal, Pattern, UnpackPattern};
+pub use sappho_gast::{Identifier, ListExpr, Literal, Pattern, UnpackPattern};
 pub type ApplicationExpr<FX> = sappho_gast::ApplicationExpr<GenExpr<FX>>;
 pub type LetExpr<FX> = sappho_gast::LetExpr<GenExpr<FX>>;
 pub type LetClause<FX> = sappho_gast::LetClause<GenExpr<FX>>;

--- a/eval/src/expr.rs
+++ b/eval/src/expr.rs
@@ -1,7 +1,7 @@
 mod application;
 mod effects;
 mod letexpr;
-mod listform;
+mod listexpr;
 mod literal;
 mod lookup;
 mod matchexpr;

--- a/eval/src/expr/listexpr.rs
+++ b/eval/src/expr/listexpr.rs
@@ -1,8 +1,8 @@
 use crate::{Eval, EvalV, Result};
-use sappho_east::{GenExpr, ListForm};
+use sappho_east::{GenExpr, ListExpr};
 use sappho_value::{List, ScopeRef, Value};
 
-impl<FX> EvalV for ListForm<GenExpr<FX>>
+impl<FX> EvalV for ListExpr<GenExpr<FX>>
 where
     FX: Eval,
 {

--- a/gast/src/lib.rs
+++ b/gast/src/lib.rs
@@ -1,7 +1,7 @@
 mod application;
 mod func;
 mod letexpr;
-mod listform;
+mod listexpr;
 mod literal;
 mod lookup;
 mod matchexpr;
@@ -12,7 +12,7 @@ mod query;
 pub use self::application::ApplicationExpr;
 pub use self::func::FuncDef;
 pub use self::letexpr::{LetClause, LetExpr};
-pub use self::listform::ListForm;
+pub use self::listexpr::ListExpr;
 pub use self::literal::Literal;
 pub use self::lookup::LookupExpr;
 pub use self::matchexpr::{MatchClause, MatchExpr};

--- a/gast/src/listexpr.rs
+++ b/gast/src/listexpr.rs
@@ -2,30 +2,30 @@ use std::fmt;
 
 /// A general structure for a sequence of items, such as a list expression, ie `[x, 42, y]`.
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
-pub struct ListForm<T>(Vec<T>);
+pub struct ListExpr<T>(Vec<T>);
 
-impl<T> ListForm<T> {
+impl<T> ListExpr<T> {
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.0.iter()
     }
 }
 
-impl<T> AsRef<[T]> for ListForm<T> {
+impl<T> AsRef<[T]> for ListExpr<T> {
     fn as_ref(&self) -> &[T] {
         self.0.as_ref()
     }
 }
 
-impl<T> FromIterator<T> for ListForm<T> {
+impl<T> FromIterator<T> for ListExpr<T> {
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        ListForm(iter.into_iter().collect())
+        ListExpr(iter.into_iter().collect())
     }
 }
 
-impl<T> IntoIterator for ListForm<T> {
+impl<T> IntoIterator for ListExpr<T> {
     type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
     type Item = T;
 
@@ -34,7 +34,7 @@ impl<T> IntoIterator for ListForm<T> {
     }
 }
 
-impl<T> fmt::Display for ListForm<T>
+impl<T> fmt::Display for ListExpr<T>
 where
     T: fmt::Display,
 {

--- a/parser/src/expr/recursive.rs
+++ b/parser/src/expr/recursive.rs
@@ -1,13 +1,13 @@
 use crate::error::BareError;
 use crate::expr::pattern::pattern;
 use crate::keyword::Keyword;
-use crate::listform::list_form;
+use crate::listexpr::list_form;
 use crate::space::ws;
 use chumsky::primitive::just;
 use chumsky::recursive::Recursive;
 use chumsky::Parser;
 use sappho_ast::{GenExpr, LetClause, LetExpr, MatchClause, MatchExpr};
-use sappho_gast::ListForm;
+use sappho_gast::ListExpr;
 
 pub(crate) fn recursive_expr<'a, FX: 'a>(
     expr: Recursive<'a, char, GenExpr<FX>, BareError>,
@@ -22,7 +22,7 @@ pub(crate) fn recursive_expr<'a, FX: 'a>(
 
 fn list_expr<'a, FX: 'a>(
     expr: Recursive<'a, char, GenExpr<FX>, BareError>,
-) -> impl Parser<char, ListForm<GenExpr<FX>>, Error = BareError> + 'a {
+) -> impl Parser<char, ListExpr<GenExpr<FX>>, Error = BareError> + 'a {
     list_form(expr).labelled("list-expression")
 }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -2,7 +2,7 @@ mod delimited;
 mod error;
 mod expr;
 mod keyword;
-mod listform;
+mod listexpr;
 mod restrict;
 mod space;
 

--- a/parser/src/listexpr.rs
+++ b/parser/src/listexpr.rs
@@ -3,9 +3,9 @@ use crate::error::BareError;
 use crate::space::ws;
 use chumsky::primitive::just;
 use chumsky::Parser;
-use sappho_gast::ListForm;
+use sappho_gast::ListExpr;
 
-pub(crate) fn list_form<P, O>(item: P) -> impl Parser<char, ListForm<O>, Error = BareError>
+pub(crate) fn list_form<P, O>(item: P) -> impl Parser<char, ListExpr<O>, Error = BareError>
 where
     P: Parser<char, O, Error = BareError>,
 {
@@ -14,5 +14,5 @@ where
         item.separated_by(just(',').then_ignore(ws().or_not())),
         ']',
     )
-    .map(ListForm::from)
+    .map(ListExpr::from)
 }

--- a/parser/src/restrict.rs
+++ b/parser/src/restrict.rs
@@ -4,7 +4,7 @@ use sappho_ast::{
     ApplicationExpr, GenExpr, LetClause, LetExpr, LookupExpr, MatchClause, MatchExpr, ProcEffects,
     PureEffects, QueryEffects, QueryExpr,
 };
-use sappho_gast::ListForm;
+use sappho_gast::ListExpr;
 
 pub(crate) trait Restrict<S>: Sized {
     fn restrict(src: S, span: Span) -> Result<Self, BareError>;
@@ -57,7 +57,7 @@ where
             List(x) => Ok(List(
                 x.into_iter()
                     .map(|subx| GenExpr::<FXD>::restrict(subx, span.clone()))
-                    .collect::<Result<ListForm<_>, BareError>>()?,
+                    .collect::<Result<ListExpr<_>, BareError>>()?,
             )),
             Let(x) => LetExpr::restrict(x, span).map(Let),
             Match(x) => MatchExpr::restrict(x, span).map(Match),


### PR DESCRIPTION
Closes #55.