### PR TITLE
Remove vestigial `sappho_value::List`.

### DIFF
--- a/value/src/lib.rs
+++ b/value/src/lib.rs
@@ -1,6 +1,5 @@
 mod coerce;
 mod func;
-mod list;
 mod object;
 mod query;
 mod scope;
@@ -10,7 +9,6 @@ mod value;
 
 pub use self::coerce::{Coerce, CoercionFailure};
 pub use self::func::Func;
-pub use self::list::List;
 pub use self::object::{Attrs, Object};
 pub use self::query::Query;
 pub use self::scope::{

--- a/value/src/value.rs
+++ b/value/src/value.rs
@@ -1,11 +1,10 @@
-use crate::{List, Object, ValRef};
+use crate::{Object, ValRef};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use std::fmt;
 
 #[derive(Debug, derive_more::From)]
 pub enum Value {
     Num(f64),
-    List(List),
     Object(Box<Object>),
 }
 
@@ -24,7 +23,6 @@ impl fmt::Display for Value {
 
         match self {
             Num(x) => x.fmt(f),
-            List(x) => x.fmt(f),
             Object(x) => {
                 if let Some(list) = x.try_into_identmap().and_then(|m| m.as_list_form()) {
                     list.fmt(f)


### PR DESCRIPTION
This was a missing followup from #60 and #61.