### PR TITLE
Add a dev tool to rewrite integration test expectations with current binary.

### DIFF
--- a/devtools/rewrite-integration-tests.sh
+++ b/devtools/rewrite-integration-tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT="$(readlink -f "$0")"
+PROJDIR="$(dirname "$(dirname "$SCRIPT")")"
+
+cd $PROJDIR
+cargo build
+
+cd ./integration-tests/src
+
+set -x
+for casedir in test-cases/*
+do
+  input="$(ls "$casedir"/input* | head -1)"
+  cp "$input" "$input.tmp"
+  sappho eval "$input.tmp" > "$casedir/expected" 2>&1 || true
+  for style in canonical reduced
+  do
+    sappho parse -f "$style" "$input.tmp" > "$casedir/input-$style" || true
+  done
+  rm "$input.tmp"
+done
+set +x

--- a/devtools/rewrite-integration-tests.sh
+++ b/devtools/rewrite-integration-tests.sh
@@ -14,15 +14,15 @@ for casedir in test-cases/*
 do
   echo "Updating $casedir..."
   input="$(ls "$casedir"/input* | head -1)"
-  cp "$input" "$input.tmp"
-  if sappho eval "$input.tmp" > "$casedir/expected" 2>&1
+  if sappho eval "$input" > "$casedir/expected" 2>&1
   then
     # It successfully parsed and evaluated, so do source code rewrites:
     echo "Updating $casedir unparse expectations..."
+    cp "$input" "$input.tmp"
     for style in canonical reduced
     do
       sappho parse -f "$style" "$input.tmp" > "$casedir/input-$style" || true
     done
+    rm "$input.tmp"
   fi
-  rm "$input.tmp"
 done

--- a/devtools/rewrite-integration-tests.sh
+++ b/devtools/rewrite-integration-tests.sh
@@ -10,16 +10,19 @@ cargo build
 
 cd ./integration-tests/src
 
-set -x
 for casedir in test-cases/*
 do
+  echo "Updating $casedir..."
   input="$(ls "$casedir"/input* | head -1)"
   cp "$input" "$input.tmp"
-  sappho eval "$input.tmp" > "$casedir/expected" 2>&1 || true
-  for style in canonical reduced
-  do
-    sappho parse -f "$style" "$input.tmp" > "$casedir/input-$style" || true
-  done
+  if sappho eval "$input.tmp" > "$casedir/expected" 2>&1
+  then
+    # It successfully parsed and evaluated, so do source code rewrites:
+    echo "Updating $casedir unparse expectations..."
+    for style in canonical reduced
+    do
+      sappho parse -f "$style" "$input.tmp" > "$casedir/input-$style" || true
+    done
+  fi
   rm "$input.tmp"
 done
-set +x

--- a/integration-tests/src/test-cases/parse-error-bad-numlit/expected
+++ b/integration-tests/src/test-cases/parse-error-bad-numlit/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-bad-numlit/input", line 1:
 |  ^
 |
 +-> Syntax error: unexpected 't' in numeric literal
+

--- a/integration-tests/src/test-cases/parse-error-bad-parens/expected
+++ b/integration-tests/src/test-cases/parse-error-bad-parens/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-bad-parens/input", line 1:
 |   ^
 |
 +-> Syntax error: while parsing parenthetical-expression, unexpected ']' while expecting ' ', '!', '$', '(', '[', '\n', 'f', 'l', 'm', 'q', or '{'
+

--- a/integration-tests/src/test-cases/parse-error-bare-evocation/expected
+++ b/integration-tests/src/test-cases/parse-error-bare-evocation/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-bare-evocation/input", line 1:
 | ^^
 |
 +-> Syntax error: pure expressions cannot contain evoke effects, e.g. `!…`
+

--- a/integration-tests/src/test-cases/parse-error-bare-inquiry/expected
+++ b/integration-tests/src/test-cases/parse-error-bare-inquiry/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-bare-inquiry/input", line 1:
 | ^^
 |
 +-> Syntax error: pure expressions cannot contain inquiry effects, e.g. `$…`
+

--- a/integration-tests/src/test-cases/parse-error-duplicate-attrs/expected
+++ b/integration-tests/src/test-cases/parse-error-duplicate-attrs/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-duplicate-attrs/input", line 1:
 | ^
 |
 +-> Syntax error: while parsing object definition, duplicate attribute "a"
+

--- a/integration-tests/src/test-cases/parse-error-evocation-in-query/expected
+++ b/integration-tests/src/test-cases/parse-error-evocation-in-query/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-evocation-in-query/input", line 1:
 |       ^^
 |
 +-> Syntax error: while parsing query definition, query expressions cannot contain evoke effects, e.g. `!…`
+

--- a/integration-tests/src/test-cases/parse-error-inquiry-space/expected
+++ b/integration-tests/src/test-cases/parse-error-inquiry-space/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-inquiry-space/input", line 1:
 |        ^
 |
 +-> Syntax error: while parsing parenthetical-expression, unexpected ' ' while expecting '!', '$', '(', '[', 'f', 'l', 'm', 'q', or '{'
+

--- a/integration-tests/src/test-cases/parse-error-invalid-let-syntax/expected
+++ b/integration-tests/src/test-cases/parse-error-invalid-let-syntax/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-invalid-let-syntax/input", line 2:
 |     ^
 |
 +-> Syntax error: while parsing pattern, unexpected ' ' while expecting ':'
+

--- a/integration-tests/src/test-cases/parse-error-num-letter/expected
+++ b/integration-tests/src/test-cases/parse-error-num-letter/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-num-letter/input", line 1:
 |  ^
 |
 +-> Syntax error: unexpected 'x' in numeric literal
+

--- a/integration-tests/src/test-cases/parse-error-open-square-bracket/expected
+++ b/integration-tests/src/test-cases/parse-error-open-square-bracket/expected
@@ -3,3 +3,4 @@ parse error: from "test-cases/parse-error-open-square-bracket/input", line 1:
 |  ^
 |
 +-> Syntax error: while parsing list-expression, unexpected end of input while expecting ' ', '!', '$', '(', '.', '[', '\n', ']', 'f', 'l', 'm', 'q', or '{'
+


### PR DESCRIPTION
The output of this tool must be validated by a developer to ensure it's not introducing incorrect expectations.