### PR TITLE
Unparse stream

### DIFF
--- a/ast/src/effects/proc.rs
+++ b/ast/src/effects/proc.rs
@@ -22,7 +22,7 @@ impl From<ProcEffects> for ProcExpr {
 }
 
 impl Unparse for ProcEffects {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use ProcEffects::*;
 
         match self {

--- a/ast/src/effects/proc.rs
+++ b/ast/src/effects/proc.rs
@@ -1,5 +1,5 @@
 use crate::GenExpr;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// Proc expressions can cause mutations (in memory or I/O), as in `!launch_balloon`, as well as
 /// causing [QueryEffects](crate::QueryEffects).
@@ -21,18 +21,18 @@ impl From<ProcEffects> for ProcExpr {
     }
 }
 
-impl DisplayDepth for ProcEffects {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for ProcEffects {
+    fn unparse(&self) -> Stream {
         use ProcEffects::*;
 
         match self {
             Inquire(x) => {
                 write!(f, "$")?;
-                x.fmt_depth(f, depth)
+                x.unparse(f, depth)
             }
             Evoke(x) => {
                 write!(f, "!")?;
-                x.fmt_depth(f, depth)
+                x.unparse(f, depth)
             }
         }
     }

--- a/ast/src/effects/proc.rs
+++ b/ast/src/effects/proc.rs
@@ -27,11 +27,11 @@ impl Unparse for ProcEffects {
 
         match self {
             Inquire(x) => {
-                s.write("$");
+                s.write(&"$");
                 s.write(x);
             }
             Evoke(x) => {
-                s.write("!");
+                s.write(&"!");
                 s.write(x);
             }
         }

--- a/ast/src/effects/proc.rs
+++ b/ast/src/effects/proc.rs
@@ -27,12 +27,12 @@ impl Unparse for ProcEffects {
 
         match self {
             Inquire(x) => {
-                s.write_str("$");
-                x.unparse_into(s);
+                s.write("$");
+                s.write(x);
             }
             Evoke(x) => {
-                s.write_str("!");
-                x.unparse_into(s);
+                s.write("!");
+                s.write(x);
             }
         }
     }

--- a/ast/src/effects/proc.rs
+++ b/ast/src/effects/proc.rs
@@ -1,5 +1,5 @@
 use crate::GenExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// Proc expressions can cause mutations (in memory or I/O), as in `!launch_balloon`, as well as
 /// causing [QueryEffects](crate::QueryEffects).
@@ -27,12 +27,12 @@ impl Unparse for ProcEffects {
 
         match self {
             Inquire(x) => {
-                write!(f, "$")?;
-                x.unparse(f, depth)
+                s.write_str("$");
+                x.unparse_into(s);
             }
             Evoke(x) => {
-                write!(f, "!")?;
-                x.unparse(f, depth)
+                s.write_str("!");
+                x.unparse_into(s);
             }
         }
     }

--- a/ast/src/effects/pure.rs
+++ b/ast/src/effects/pure.rs
@@ -1,5 +1,5 @@
 use crate::GenExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// Pure expressions without side-effects.
 pub type PureExpr = GenExpr<PureEffects>;
@@ -9,7 +9,7 @@ pub type PureExpr = GenExpr<PureEffects>;
 pub enum PureEffects {}
 
 impl Unparse for PureEffects {
-    fn unparse_into(&self, s: &mut Stream) {
+    fn unparse_into(&self, _s: &mut Stream) {
         unreachable!("pure effects are never instantiated");
     }
 }

--- a/ast/src/effects/pure.rs
+++ b/ast/src/effects/pure.rs
@@ -1,5 +1,5 @@
 use crate::GenExpr;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// Pure expressions without side-effects.
 pub type PureExpr = GenExpr<PureEffects>;
@@ -8,8 +8,8 @@ pub type PureExpr = GenExpr<PureEffects>;
 #[derive(Clone, Debug, PartialEq)]
 pub enum PureEffects {}
 
-impl DisplayDepth for PureEffects {
-    fn fmt_depth(&self, _f: &mut Formatter, _depth: usize) -> FmtResult {
+impl Unparse for PureEffects {
+    fn unparse(&self) -> Stream {
         unreachable!("pure effects are never instantiated");
     }
 }

--- a/ast/src/effects/pure.rs
+++ b/ast/src/effects/pure.rs
@@ -9,7 +9,7 @@ pub type PureExpr = GenExpr<PureEffects>;
 pub enum PureEffects {}
 
 impl Unparse for PureEffects {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         unreachable!("pure effects are never instantiated");
     }
 }

--- a/ast/src/effects/query.rs
+++ b/ast/src/effects/query.rs
@@ -1,5 +1,5 @@
 use crate::GenExpr;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// Query expressions can read mutable memory, as in `$myvar`.
 pub type QueryExpr = GenExpr<QueryEffects>;
@@ -17,14 +17,14 @@ impl From<QueryEffects> for QueryExpr {
     }
 }
 
-impl DisplayDepth for QueryEffects {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for QueryEffects {
+    fn unparse(&self) -> Stream {
         use QueryEffects::*;
 
         match self {
             Inquire(x) => {
                 write!(f, "$")?;
-                x.fmt_depth(f, depth)
+                x.unparse(f, depth)
             }
         }
     }

--- a/ast/src/effects/query.rs
+++ b/ast/src/effects/query.rs
@@ -23,7 +23,7 @@ impl Unparse for QueryEffects {
 
         match self {
             Inquire(x) => {
-                s.write("$");
+                s.write(&"$");
                 s.write(x);
             }
         }

--- a/ast/src/effects/query.rs
+++ b/ast/src/effects/query.rs
@@ -23,8 +23,8 @@ impl Unparse for QueryEffects {
 
         match self {
             Inquire(x) => {
-                s.write_str("$");
-                x.unparse_into(s);
+                s.write("$");
+                s.write(x);
             }
         }
     }

--- a/ast/src/effects/query.rs
+++ b/ast/src/effects/query.rs
@@ -1,5 +1,5 @@
 use crate::GenExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// Query expressions can read mutable memory, as in `$myvar`.
 pub type QueryExpr = GenExpr<QueryEffects>;
@@ -23,8 +23,8 @@ impl Unparse for QueryEffects {
 
         match self {
             Inquire(x) => {
-                write!(f, "$")?;
-                x.unparse(f, depth)
+                s.write_str("$");
+                x.unparse_into(s);
             }
         }
     }

--- a/ast/src/effects/query.rs
+++ b/ast/src/effects/query.rs
@@ -18,7 +18,7 @@ impl From<QueryEffects> for QueryExpr {
 }
 
 impl Unparse for QueryEffects {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use QueryEffects::*;
 
         match self {

--- a/ast/src/expr.rs
+++ b/ast/src/expr.rs
@@ -5,7 +5,7 @@ use crate::{
     ObjectDef, QueryDef,
 };
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// The general top-level expression for all effects.
 #[derive(Debug, PartialEq)]
@@ -103,17 +103,17 @@ where
         use GenExpr::*;
 
         match self {
-            Lit(x) => x.unparse(f, depth),
-            Ref(x) => x.unparse(f, depth),
-            Func(x) => x.unparse(f, depth),
-            Query(x) => x.unparse(f, depth),
-            Object(x) => x.unparse(f, depth),
-            List(x) => x.unparse(f, depth),
-            Let(x) => x.unparse(f, depth),
-            Match(x) => x.unparse(f, depth),
-            Application(x) => x.unparse(f, depth),
-            Lookup(x) => x.unparse(f, depth),
-            Effect(x) => x.unparse(f, depth),
+            Lit(x) => x.unparse_into(s),
+            Ref(x) => x.unparse_into(s),
+            Func(x) => x.unparse_into(s),
+            Query(x) => x.unparse_into(s),
+            Object(x) => x.unparse_into(s),
+            List(x) => x.unparse_into(s),
+            Let(x) => x.unparse_into(s),
+            Match(x) => x.unparse_into(s),
+            Application(x) => x.unparse_into(s),
+            Lookup(x) => x.unparse_into(s),
+            Effect(x) => x.unparse_into(s),
         }
     }
 }
@@ -123,6 +123,6 @@ where
     FX: Unparse,
 {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.unparse(f, 0)
+        self.unparse().fmt(f)
     }
 }

--- a/ast/src/expr.rs
+++ b/ast/src/expr.rs
@@ -99,7 +99,7 @@ impl<FX> Unparse for GenExpr<FX>
 where
     FX: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use GenExpr::*;
 
         match self {

--- a/ast/src/expr.rs
+++ b/ast/src/expr.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use sappho_unparse::{Stream, Unparse};
+use std::fmt;
 
 /// The general top-level expression for all effects.
 #[derive(Debug, PartialEq)]
@@ -118,11 +119,11 @@ where
     }
 }
 
-impl<FX> std::fmt::Display for GenExpr<FX>
+impl<FX> fmt::Display for GenExpr<FX>
 where
     FX: Unparse,
 {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.unparse().fmt(f)
     }
 }

--- a/ast/src/expr.rs
+++ b/ast/src/expr.rs
@@ -5,7 +5,7 @@ use crate::{
     ObjectDef, QueryDef,
 };
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// The general top-level expression for all effects.
 #[derive(Debug, PartialEq)]
@@ -95,34 +95,34 @@ impl<FX> TryIntoIdentMap<GenExpr<FX>> for GenExpr<FX> {
     }
 }
 
-impl<FX> DisplayDepth for GenExpr<FX>
+impl<FX> Unparse for GenExpr<FX>
 where
-    FX: DisplayDepth,
+    FX: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+    fn unparse(&self) -> Stream {
         use GenExpr::*;
 
         match self {
-            Lit(x) => x.fmt_depth(f, depth),
-            Ref(x) => x.fmt_depth(f, depth),
-            Func(x) => x.fmt_depth(f, depth),
-            Query(x) => x.fmt_depth(f, depth),
-            Object(x) => x.fmt_depth(f, depth),
-            List(x) => x.fmt_depth(f, depth),
-            Let(x) => x.fmt_depth(f, depth),
-            Match(x) => x.fmt_depth(f, depth),
-            Application(x) => x.fmt_depth(f, depth),
-            Lookup(x) => x.fmt_depth(f, depth),
-            Effect(x) => x.fmt_depth(f, depth),
+            Lit(x) => x.unparse(f, depth),
+            Ref(x) => x.unparse(f, depth),
+            Func(x) => x.unparse(f, depth),
+            Query(x) => x.unparse(f, depth),
+            Object(x) => x.unparse(f, depth),
+            List(x) => x.unparse(f, depth),
+            Let(x) => x.unparse(f, depth),
+            Match(x) => x.unparse(f, depth),
+            Application(x) => x.unparse(f, depth),
+            Lookup(x) => x.unparse(f, depth),
+            Effect(x) => x.unparse(f, depth),
         }
     }
 }
 
 impl<FX> std::fmt::Display for GenExpr<FX>
 where
-    FX: DisplayDepth,
+    FX: Unparse,
 {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.fmt_depth(f, 0)
+        self.unparse(f, 0)
     }
 }

--- a/ast/src/pattern.rs
+++ b/ast/src/pattern.rs
@@ -2,7 +2,7 @@ mod unpack;
 
 use crate::{Identifier, Literal};
 use sappho_listform::ListForm;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 pub use self::unpack::UnpackPattern;
 
@@ -21,10 +21,10 @@ impl Unparse for Pattern {
         use Pattern::*;
 
         match self {
-            Bind(x) => x.unparse(f, depth),
-            LitEq(x) => x.unparse(f, depth),
-            Unpack(x) => x.unparse(f, depth),
-            List(x) => x.unparse(f, depth),
+            Bind(x) => x.unparse_into(s),
+            LitEq(x) => x.unparse_into(s),
+            Unpack(x) => x.unparse_into(s),
+            List(x) => x.unparse_into(s),
         }
     }
 }

--- a/ast/src/pattern.rs
+++ b/ast/src/pattern.rs
@@ -17,7 +17,7 @@ pub enum Pattern {
 }
 
 impl Unparse for Pattern {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use Pattern::*;
 
         match self {

--- a/ast/src/pattern.rs
+++ b/ast/src/pattern.rs
@@ -2,7 +2,7 @@ mod unpack;
 
 use crate::{Identifier, Literal};
 use sappho_listform::ListForm;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 pub use self::unpack::UnpackPattern;
 
@@ -16,15 +16,15 @@ pub enum Pattern {
     List(ListPattern),
 }
 
-impl DisplayDepth for Pattern {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for Pattern {
+    fn unparse(&self) -> Stream {
         use Pattern::*;
 
         match self {
-            Bind(x) => x.fmt_depth(f, depth),
-            LitEq(x) => x.fmt_depth(f, depth),
-            Unpack(x) => x.fmt_depth(f, depth),
-            List(x) => x.fmt_depth(f, depth),
+            Bind(x) => x.unparse(f, depth),
+            LitEq(x) => x.unparse(f, depth),
+            Unpack(x) => x.unparse(f, depth),
+            List(x) => x.unparse(f, depth),
         }
     }
 }

--- a/ast/src/pattern/unpack.rs
+++ b/ast/src/pattern/unpack.rs
@@ -1,6 +1,6 @@
 use crate::Pattern;
 use sappho_identmap::{IdentMap, Identifier};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 use std::ops::Deref;
 
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
@@ -32,8 +32,8 @@ impl Deref for UnpackPattern {
     }
 }
 
-impl DisplayDepth for UnpackPattern {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.0.fmt_depth(f, depth)
+impl Unparse for UnpackPattern {
+    fn unparse(&self) -> Stream {
+        self.0.unparse(f, depth)
     }
 }

--- a/ast/src/pattern/unpack.rs
+++ b/ast/src/pattern/unpack.rs
@@ -33,7 +33,7 @@ impl Deref for UnpackPattern {
 }
 
 impl Unparse for UnpackPattern {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.0.unparse(f, depth)
     }
 }

--- a/ast/src/pattern/unpack.rs
+++ b/ast/src/pattern/unpack.rs
@@ -1,6 +1,6 @@
 use crate::Pattern;
 use sappho_identmap::{IdentMap, Identifier};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 use std::ops::Deref;
 
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
@@ -34,6 +34,6 @@ impl Deref for UnpackPattern {
 
 impl Unparse for UnpackPattern {
     fn unparse_into(&self, s: &mut Stream) {
-        self.0.unparse(f, depth)
+        self.0.unparse_into(s)
     }
 }

--- a/east/src/effects/proc.rs
+++ b/east/src/effects/proc.rs
@@ -42,11 +42,11 @@ impl Unparse for ProcEffects {
 
         match self {
             Inquire(x) => {
-                s.write("$");
+                s.write(&"$");
                 s.write(x);
             }
             Evoke(x) => {
-                s.write("!");
+                s.write(&"!");
                 s.write(x);
             }
         }

--- a/east/src/effects/proc.rs
+++ b/east/src/effects/proc.rs
@@ -1,6 +1,6 @@
 use crate::{FromFx, GenExpr};
 use sappho_ast as ast;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 pub type ProcExpr = GenExpr<ProcEffects>;
 
@@ -36,18 +36,18 @@ impl FromFx for ast::ProcEffects {
     }
 }
 
-impl DisplayDepth for ProcEffects {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for ProcEffects {
+    fn unparse(&self) -> Stream {
         use ProcEffects::*;
 
         match self {
             Inquire(x) => {
                 write!(f, "$")?;
-                x.fmt_depth(f, depth)
+                x.unparse(f, depth)
             }
             Evoke(x) => {
                 write!(f, "!")?;
-                x.fmt_depth(f, depth)
+                x.unparse(f, depth)
             }
         }
     }

--- a/east/src/effects/proc.rs
+++ b/east/src/effects/proc.rs
@@ -1,6 +1,6 @@
 use crate::{FromFx, GenExpr};
 use sappho_ast as ast;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 pub type ProcExpr = GenExpr<ProcEffects>;
 
@@ -42,12 +42,12 @@ impl Unparse for ProcEffects {
 
         match self {
             Inquire(x) => {
-                write!(f, "$")?;
-                x.unparse(f, depth)
+                s.write_str("$");
+                x.unparse_into(s);
             }
             Evoke(x) => {
-                write!(f, "!")?;
-                x.unparse(f, depth)
+                s.write_str("!");
+                x.unparse_into(s);
             }
         }
     }

--- a/east/src/effects/proc.rs
+++ b/east/src/effects/proc.rs
@@ -42,12 +42,12 @@ impl Unparse for ProcEffects {
 
         match self {
             Inquire(x) => {
-                s.write_str("$");
-                x.unparse_into(s);
+                s.write("$");
+                s.write(x);
             }
             Evoke(x) => {
-                s.write_str("!");
-                x.unparse_into(s);
+                s.write("!");
+                s.write(x);
             }
         }
     }

--- a/east/src/effects/proc.rs
+++ b/east/src/effects/proc.rs
@@ -37,7 +37,7 @@ impl FromFx for ast::ProcEffects {
 }
 
 impl Unparse for ProcEffects {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use ProcEffects::*;
 
         match self {

--- a/east/src/effects/query.rs
+++ b/east/src/effects/query.rs
@@ -39,7 +39,7 @@ impl Unparse for QueryEffects {
 
         match self {
             Inquire(x) => {
-                s.write("$");
+                s.write(&"$");
                 s.write(x);
             }
         }

--- a/east/src/effects/query.rs
+++ b/east/src/effects/query.rs
@@ -1,6 +1,6 @@
 use crate::{FromFx, GenExpr};
 use sappho_ast as ast;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 pub type QueryExpr = GenExpr<QueryEffects>;
 
@@ -33,14 +33,14 @@ impl FromFx for ast::QueryEffects {
     }
 }
 
-impl DisplayDepth for QueryEffects {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for QueryEffects {
+    fn unparse(&self) -> Stream {
         use QueryEffects::*;
 
         match self {
             Inquire(x) => {
                 write!(f, "$")?;
-                x.fmt_depth(f, depth)
+                x.unparse(f, depth)
             }
         }
     }

--- a/east/src/effects/query.rs
+++ b/east/src/effects/query.rs
@@ -34,7 +34,7 @@ impl FromFx for ast::QueryEffects {
 }
 
 impl Unparse for QueryEffects {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use QueryEffects::*;
 
         match self {

--- a/east/src/effects/query.rs
+++ b/east/src/effects/query.rs
@@ -39,8 +39,8 @@ impl Unparse for QueryEffects {
 
         match self {
             Inquire(x) => {
-                s.write_str("$");
-                x.unparse_into(s);
+                s.write("$");
+                s.write(x);
             }
         }
     }

--- a/east/src/effects/query.rs
+++ b/east/src/effects/query.rs
@@ -1,6 +1,6 @@
 use crate::{FromFx, GenExpr};
 use sappho_ast as ast;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 pub type QueryExpr = GenExpr<QueryEffects>;
 
@@ -39,8 +39,8 @@ impl Unparse for QueryEffects {
 
         match self {
             Inquire(x) => {
-                write!(f, "$")?;
-                x.unparse(f, depth)
+                s.write_str("$");
+                x.unparse_into(s);
             }
         }
     }

--- a/east/src/expr.rs
+++ b/east/src/expr.rs
@@ -5,6 +5,7 @@ use crate::{
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use sappho_unparse::{Stream, Unparse};
+use std::fmt;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GenExpr<Effects> {
@@ -139,11 +140,11 @@ where
     }
 }
 
-impl<FX> std::fmt::Display for GenExpr<FX>
+impl<FX> fmt::Display for GenExpr<FX>
 where
     FX: Unparse,
 {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.unparse(f, 0)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.unparse().fmt(f)
     }
 }

--- a/east/src/expr.rs
+++ b/east/src/expr.rs
@@ -123,7 +123,7 @@ impl<FX> Unparse for GenExpr<FX>
 where
     FX: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use GenExpr::*;
 
         match self {

--- a/east/src/expr.rs
+++ b/east/src/expr.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GenExpr<Effects> {
@@ -119,31 +119,31 @@ impl<FX> TryIntoIdentMap<GenExpr<FX>> for GenExpr<FX> {
     }
 }
 
-impl<FX> DisplayDepth for GenExpr<FX>
+impl<FX> Unparse for GenExpr<FX>
 where
-    FX: DisplayDepth,
+    FX: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+    fn unparse(&self) -> Stream {
         use GenExpr::*;
 
         match self {
-            Lit(x) => x.fmt_depth(f, depth),
-            Ref(x) => x.fmt_depth(f, depth),
-            Object(x) => x.fmt_depth(f, depth),
-            Let(x) => x.fmt_depth(f, depth),
-            Match(x) => x.fmt_depth(f, depth),
-            Application(x) => x.fmt_depth(f, depth),
-            Lookup(x) => x.fmt_depth(f, depth),
-            Effect(x) => x.fmt_depth(f, depth),
+            Lit(x) => x.unparse(f, depth),
+            Ref(x) => x.unparse(f, depth),
+            Object(x) => x.unparse(f, depth),
+            Let(x) => x.unparse(f, depth),
+            Match(x) => x.unparse(f, depth),
+            Application(x) => x.unparse(f, depth),
+            Lookup(x) => x.unparse(f, depth),
+            Effect(x) => x.unparse(f, depth),
         }
     }
 }
 
 impl<FX> std::fmt::Display for GenExpr<FX>
 where
-    FX: DisplayDepth,
+    FX: Unparse,
 {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.fmt_depth(f, 0)
+        self.unparse(f, 0)
     }
 }

--- a/east/src/expr.rs
+++ b/east/src/expr.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GenExpr<Effects> {
@@ -127,14 +127,14 @@ where
         use GenExpr::*;
 
         match self {
-            Lit(x) => x.unparse(f, depth),
-            Ref(x) => x.unparse(f, depth),
-            Object(x) => x.unparse(f, depth),
-            Let(x) => x.unparse(f, depth),
-            Match(x) => x.unparse(f, depth),
-            Application(x) => x.unparse(f, depth),
-            Lookup(x) => x.unparse(f, depth),
-            Effect(x) => x.unparse(f, depth),
+            Lit(x) => x.unparse_into(s),
+            Ref(x) => x.unparse_into(s),
+            Object(x) => x.unparse_into(s),
+            Let(x) => x.unparse_into(s),
+            Match(x) => x.unparse_into(s),
+            Application(x) => x.unparse_into(s),
+            Lookup(x) => x.unparse_into(s),
+            Effect(x) => x.unparse_into(s),
         }
     }
 }

--- a/east/src/pattern.rs
+++ b/east/src/pattern.rs
@@ -3,7 +3,7 @@ mod unpack;
 use crate::{Identifier, Literal};
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 pub use self::unpack::UnpackPattern;
 
@@ -75,21 +75,21 @@ impl From<Pattern> for ast::Pattern {
     }
 }
 
-impl DisplayDepth for Pattern {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for Pattern {
+    fn unparse(&self) -> Stream {
         use Pattern::*;
 
         match self {
-            Bind(x) => x.fmt_depth(f, depth),
-            LitEq(x) => x.fmt_depth(f, depth),
-            Unpack(x) => x.fmt_depth(f, depth),
+            Bind(x) => x.unparse(f, depth),
+            LitEq(x) => x.unparse(f, depth),
+            Unpack(x) => x.unparse(f, depth),
         }
     }
 }
 
 impl std::fmt::Display for Pattern {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.fmt_depth(f, 0)
+        self.unparse(f, 0)
     }
 }
 

--- a/east/src/pattern.rs
+++ b/east/src/pattern.rs
@@ -76,7 +76,7 @@ impl From<Pattern> for ast::Pattern {
 }
 
 impl Unparse for Pattern {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use Pattern::*;
 
         match self {

--- a/east/src/pattern.rs
+++ b/east/src/pattern.rs
@@ -3,7 +3,7 @@ mod unpack;
 use crate::{Identifier, Literal};
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 pub use self::unpack::UnpackPattern;
 
@@ -80,9 +80,9 @@ impl Unparse for Pattern {
         use Pattern::*;
 
         match self {
-            Bind(x) => x.unparse(f, depth),
-            LitEq(x) => x.unparse(f, depth),
-            Unpack(x) => x.unparse(f, depth),
+            Bind(x) => x.unparse_into(s),
+            LitEq(x) => x.unparse_into(s),
+            Unpack(x) => x.unparse_into(s),
         }
     }
 }

--- a/east/src/pattern.rs
+++ b/east/src/pattern.rs
@@ -4,6 +4,7 @@ use crate::{Identifier, Literal};
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use sappho_unparse::{Stream, Unparse};
+use std::fmt;
 
 pub use self::unpack::UnpackPattern;
 
@@ -87,9 +88,9 @@ impl Unparse for Pattern {
     }
 }
 
-impl std::fmt::Display for Pattern {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.unparse(f, 0)
+impl fmt::Display for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.unparse().fmt(f)
     }
 }
 

--- a/east/src/pattern/unpack.rs
+++ b/east/src/pattern/unpack.rs
@@ -40,7 +40,7 @@ impl Deref for UnpackPattern {
 }
 
 impl Unparse for UnpackPattern {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.0.unparse(f, depth)
     }
 }

--- a/east/src/pattern/unpack.rs
+++ b/east/src/pattern/unpack.rs
@@ -1,7 +1,7 @@
 use crate::Pattern;
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, Identifier};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 use std::ops::Deref;
 
 #[derive(Clone, Debug, Default, PartialEq, derive_more::From)]
@@ -39,8 +39,8 @@ impl Deref for UnpackPattern {
     }
 }
 
-impl DisplayDepth for UnpackPattern {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.0.fmt_depth(f, depth)
+impl Unparse for UnpackPattern {
+    fn unparse(&self) -> Stream {
+        self.0.unparse(f, depth)
     }
 }

--- a/east/src/pattern/unpack.rs
+++ b/east/src/pattern/unpack.rs
@@ -1,7 +1,7 @@
 use crate::Pattern;
 use sappho_ast as ast;
 use sappho_identmap::{IdentMap, Identifier};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 use std::ops::Deref;
 
 #[derive(Clone, Debug, Default, PartialEq, derive_more::From)]
@@ -41,6 +41,6 @@ impl Deref for UnpackPattern {
 
 impl Unparse for UnpackPattern {
     fn unparse_into(&self, s: &mut Stream) {
-        self.0.unparse(f, depth)
+        self.0.unparse_into(s)
     }
 }

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Error {
             Unbound(x) => x.fmt(f),
             MissingAttr(v, name) => write!(f, "missing attr {}.{}", v, name),
             Mismatch(v, pats) => {
-                // TODO: This is a super hacky way to get the `DisplayDepth` of the patterns:
+                // TODO: This is a super hacky way to get the `Unparse` of the patterns:
                 use sappho_listform::ListForm;
 
                 write!(

--- a/eval/src/expr.rs
+++ b/eval/src/expr.rs
@@ -8,7 +8,7 @@ mod object;
 
 use crate::{Eval, Result};
 use sappho_east::GenExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::Unparse;
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for GenExpr<FX>

--- a/eval/src/expr.rs
+++ b/eval/src/expr.rs
@@ -8,12 +8,12 @@ mod object;
 
 use crate::{Eval, Result};
 use sappho_east::GenExpr;
-use sappho_unparse::DisplayDepth;
+use sappho_unparse::{Unparse, Stream};
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for GenExpr<FX>
 where
-    FX: Eval + DisplayDepth + DisplayDepth,
+    FX: Eval + Unparse + Unparse,
 {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
         log::debug!("Evaluating:\n  From: {}\n  ...\n", self);
@@ -32,7 +32,7 @@ where
 
 fn eval_expr<FX>(expr: &GenExpr<FX>, scope: &ScopeRef) -> Result<ValRef>
 where
-    FX: Eval + DisplayDepth + DisplayDepth,
+    FX: Eval + Unparse + Unparse,
 {
     use GenExpr::*;
 

--- a/eval/src/expr/application.rs
+++ b/eval/src/expr/application.rs
@@ -1,11 +1,11 @@
 use crate::{Eval, Result};
 use sappho_east::ApplicationExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::Unparse;
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for ApplicationExpr<FX>
 where
-    FX: Eval + Unparse + Unparse,
+    FX: Eval + Unparse,
 {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
         use crate::EvalThunk;

--- a/eval/src/expr/application.rs
+++ b/eval/src/expr/application.rs
@@ -1,11 +1,11 @@
 use crate::{Eval, Result};
 use sappho_east::ApplicationExpr;
-use sappho_unparse::DisplayDepth;
+use sappho_unparse::{Unparse, Stream};
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for ApplicationExpr<FX>
 where
-    FX: Eval + DisplayDepth + DisplayDepth,
+    FX: Eval + Unparse + Unparse,
 {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
         use crate::EvalThunk;

--- a/eval/src/expr/letexpr.rs
+++ b/eval/src/expr/letexpr.rs
@@ -1,11 +1,11 @@
 use crate::{Eval, Result};
 use sappho_east::LetExpr;
-use sappho_unparse::DisplayDepth;
+use sappho_unparse::{Unparse, Stream};
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for LetExpr<FX>
 where
-    FX: Eval + DisplayDepth,
+    FX: Eval + Unparse,
 {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
         // Declare all forward bindings first:

--- a/eval/src/expr/letexpr.rs
+++ b/eval/src/expr/letexpr.rs
@@ -1,6 +1,6 @@
 use crate::{Eval, Result};
 use sappho_east::LetExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::Unparse;
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for LetExpr<FX>

--- a/eval/src/expr/lookup.rs
+++ b/eval/src/expr/lookup.rs
@@ -1,6 +1,6 @@
 use crate::{Eval, Result};
 use sappho_east::LookupExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::Unparse;
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for LookupExpr<FX>

--- a/eval/src/expr/lookup.rs
+++ b/eval/src/expr/lookup.rs
@@ -1,11 +1,11 @@
 use crate::{Eval, Result};
 use sappho_east::LookupExpr;
-use sappho_unparse::DisplayDepth;
+use sappho_unparse::{Unparse, Stream};
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for LookupExpr<FX>
 where
-    FX: Eval + DisplayDepth,
+    FX: Eval + Unparse,
 {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
         use crate::Error::MissingAttr;

--- a/eval/src/expr/matchexpr.rs
+++ b/eval/src/expr/matchexpr.rs
@@ -1,6 +1,6 @@
 use crate::{Eval, Result};
 use sappho_east::MatchExpr;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::Unparse;
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for MatchExpr<FX>

--- a/eval/src/expr/matchexpr.rs
+++ b/eval/src/expr/matchexpr.rs
@@ -1,11 +1,11 @@
 use crate::{Eval, Result};
 use sappho_east::MatchExpr;
-use sappho_unparse::DisplayDepth;
+use sappho_unparse::{Unparse, Stream};
 use sappho_value::{ScopeRef, ValRef};
 
 impl<FX> Eval for MatchExpr<FX>
 where
-    FX: Eval + DisplayDepth,
+    FX: Eval + Unparse,
 {
     fn eval(&self, scope: &ScopeRef) -> Result<ValRef> {
         use crate::Error::Mismatch;

--- a/eval/src/expr/object.rs
+++ b/eval/src/expr/object.rs
@@ -1,11 +1,11 @@
 use crate::{Eval, EvalV, Result};
 use sappho_east::ObjectDef;
-use sappho_unparse::DisplayDepth;
+use sappho_unparse::{Unparse, Stream};
 use sappho_value::{Attrs, Func, Object, Query, ScopeRef, Value};
 
 impl<FX> EvalV for ObjectDef<FX>
 where
-    FX: Eval + DisplayDepth + DisplayDepth,
+    FX: Eval + Unparse + Unparse,
 {
     fn eval_val(&self, scope: &ScopeRef) -> Result<Value> {
         let mut attrs = Attrs::default();

--- a/eval/src/expr/object.rs
+++ b/eval/src/expr/object.rs
@@ -1,6 +1,6 @@
 use crate::{Eval, EvalV, Result};
 use sappho_east::ObjectDef;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::Unparse;
 use sappho_value::{Attrs, Func, Object, Query, ScopeRef, Value};
 
 impl<FX> EvalV for ObjectDef<FX>

--- a/eval/src/thunk.rs
+++ b/eval/src/thunk.rs
@@ -1,5 +1,5 @@
 use crate::{Eval, EvalThunk, Result};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::Unparse;
 use sappho_value::{GenThunk, ValRef};
 
 impl<FX> EvalThunk for GenThunk<FX>

--- a/eval/src/thunk.rs
+++ b/eval/src/thunk.rs
@@ -1,10 +1,10 @@
 use crate::{Eval, EvalThunk, Result};
-use sappho_unparse::DisplayDepth;
+use sappho_unparse::{Unparse, Stream};
 use sappho_value::{GenThunk, ValRef};
 
 impl<FX> EvalThunk for GenThunk<FX>
 where
-    FX: Eval + DisplayDepth,
+    FX: Eval + Unparse,
 {
     fn eval_thunk(&self) -> Result<ValRef> {
         let (expr, defscope) = self.peek();

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -29,7 +29,7 @@ where
     fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::Break::{Opt, OptSpace};
 
-        s.write("(");
+        s.write(&"(");
         s.write(Opt);
         {
             let mut subs = Stream::new();
@@ -39,6 +39,6 @@ where
             s.add_substream(subs);
         }
         s.write(Opt);
-        s.write(")");
+        s.write(&")");
     }
 }

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -30,9 +30,9 @@ where
         use sappho_unparse::Break::{Opt, OptSpace};
 
         s.write(&"(");
-        s.write(&Opt);
         {
             let mut subs = Stream::new();
+            subs.write(&OptSpace);
             subs.write(&self.target);
             subs.write(&OptSpace);
             subs.write(&self.argument);

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// Function application, ie `f x`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -27,17 +27,15 @@ where
     Expr: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        use sappho_unparse::{Unparse, Stream};
+        use sappho_unparse::Break::{Opt, OptSpace};
 
-        writeln!(f, "(")?;
-        indent(f, depth + 1)?;
-        self.target.unparse(f, depth + 1)?;
-        writeln!(f)?;
-        indent(f, depth + 1)?;
-        self.argument.unparse(f, depth + 1)?;
-        writeln!(f)?;
-        indent(f, depth)?;
-        write!(f, ")")?;
-        Ok(())
+        s.write_str_break("(", Opt);
+        let mut subs = Stream::new();
+        self.target.unparse(&mut subs);
+        subs.add_break(OptSpace);
+        self.argument.unparse(&mut subs);
+        s.add_substream(subs);
+        s.add_break(Opt);
+        s.write_str(")");
     }
 }

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -30,14 +30,12 @@ where
         use sappho_unparse::Break::{Opt, OptSpace};
 
         s.write(&"(");
-        {
-            let mut subs = Stream::new();
+        s.substream(|subs| {
             subs.write(&OptSpace);
             subs.write(&self.target);
             subs.write(&OptSpace);
             subs.write(&self.argument);
-            s.add_substream(subs);
-        }
+        });
         s.write(&Opt);
         s.write(&")");
     }

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -33,9 +33,9 @@ where
         s.write(&Opt);
         {
             let mut subs = Stream::new();
-            subs.write(self.target);
+            subs.write(&self.target);
             subs.write(&OptSpace);
-            subs.write(self.argument);
+            subs.write(&self.argument);
             s.add_substream(subs);
         }
         s.write(&Opt);

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -26,7 +26,7 @@ impl<Expr> Unparse for ApplicationExpr<Expr>
 where
     Expr: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::{Unparse, Stream};
 
         writeln!(f, "(")?;

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -30,15 +30,15 @@ where
         use sappho_unparse::Break::{Opt, OptSpace};
 
         s.write(&"(");
-        s.write(Opt);
+        s.write(&Opt);
         {
             let mut subs = Stream::new();
             subs.write(self.target);
-            subs.write(OptSpace);
+            subs.write(&OptSpace);
             subs.write(self.argument);
             s.add_substream(subs);
         }
-        s.write(Opt);
+        s.write(&Opt);
         s.write(&")");
     }
 }

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -29,13 +29,16 @@ where
     fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::Break::{Opt, OptSpace};
 
-        s.write_str_break("(", Opt);
-        let mut subs = Stream::new();
-        self.target.unparse(&mut subs);
-        subs.add_break(OptSpace);
-        self.argument.unparse(&mut subs);
-        s.add_substream(subs);
-        s.add_break(Opt);
-        s.write_str(")");
+        s.write("(");
+        s.write(Opt);
+        {
+            let mut subs = Stream::new();
+            subs.write(self.target);
+            subs.write(OptSpace);
+            subs.write(self.argument);
+            s.add_substream(subs);
+        }
+        s.write(Opt);
+        s.write(")");
     }
 }

--- a/gast/src/application.rs
+++ b/gast/src/application.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// Function application, ie `f x`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -22,19 +22,19 @@ impl<X> ApplicationExpr<X> {
     }
 }
 
-impl<Expr> DisplayDepth for ApplicationExpr<Expr>
+impl<Expr> Unparse for ApplicationExpr<Expr>
 where
-    Expr: DisplayDepth,
+    Expr: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        use sappho_unparse::indent;
+    fn unparse(&self) -> Stream {
+        use sappho_unparse::{Unparse, Stream};
 
         writeln!(f, "(")?;
         indent(f, depth + 1)?;
-        self.target.fmt_depth(f, depth + 1)?;
+        self.target.unparse(f, depth + 1)?;
         writeln!(f)?;
         indent(f, depth + 1)?;
-        self.argument.fmt_depth(f, depth + 1)?;
+        self.argument.unparse(f, depth + 1)?;
         writeln!(f)?;
         indent(f, depth)?;
         write!(f, ")")?;

--- a/gast/src/func.rs
+++ b/gast/src/func.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// A function definition expression, ie `fn x -> x`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -29,10 +29,9 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        write!(f, "fn ")?;
-        self.binding.unparse(f, depth)?;
-        write!(f, " -> ")?;
-        self.body.unparse(f, depth)?;
-        Ok(())
+        s.write_str("fn ");
+        self.binding.unparse(s);
+        s.write_str(" -> ");
+        self.body.unparse(s);
     }
 }

--- a/gast/src/func.rs
+++ b/gast/src/func.rs
@@ -29,9 +29,9 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write("fn ");
+        s.write(&"fn ");
         s.write(self.binding);
-        s.write(" -> ");
+        s.write(&" -> ");
         s.write(self.body);
     }
 }

--- a/gast/src/func.rs
+++ b/gast/src/func.rs
@@ -29,9 +29,9 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write_str("fn ");
-        self.binding.unparse(s);
-        s.write_str(" -> ");
-        self.body.unparse(s);
+        s.write("fn ");
+        s.write(self.binding);
+        s.write(" -> ");
+        s.write(self.body);
     }
 }

--- a/gast/src/func.rs
+++ b/gast/src/func.rs
@@ -28,7 +28,7 @@ where
     P: Unparse,
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         write!(f, "fn ")?;
         self.binding.unparse(f, depth)?;
         write!(f, " -> ")?;

--- a/gast/src/func.rs
+++ b/gast/src/func.rs
@@ -30,8 +30,8 @@ where
 {
     fn unparse_into(&self, s: &mut Stream) {
         s.write(&"fn ");
-        s.write(self.binding);
+        s.write(&self.binding);
         s.write(&" -> ");
-        s.write(self.body);
+        s.write(&self.body);
     }
 }

--- a/gast/src/func.rs
+++ b/gast/src/func.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// A function definition expression, ie `fn x -> x`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -23,16 +23,16 @@ impl<P, X> FuncDef<P, X> {
     }
 }
 
-impl<P, X> DisplayDepth for FuncDef<P, X>
+impl<P, X> Unparse for FuncDef<P, X>
 where
-    P: DisplayDepth,
-    X: DisplayDepth,
+    P: Unparse,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+    fn unparse(&self) -> Stream {
         write!(f, "fn ")?;
-        self.binding.fmt_depth(f, depth)?;
+        self.binding.unparse(f, depth)?;
         write!(f, " -> ")?;
-        self.body.fmt_depth(f, depth)?;
+        self.body.unparse(f, depth)?;
         Ok(())
     }
 }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -1,6 +1,6 @@
 mod clause;
 
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 pub use self::clause::LetClause;
 
@@ -37,31 +37,12 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        use sappho_unparse::{Unparse, Stream};
-
-        let (indented, cdepth) = if depth == 0 {
-            (false, 0)
-        } else {
-            (true, depth + 1)
-        };
-
-        if indented {
-            writeln!(f, "(")?;
-        }
+        use sappho_unparse::Break::Mandatory;
 
         for clause in self.clauses.iter() {
-            indent(f, cdepth)?;
-            clause.unparse(f, cdepth)?;
-            writeln!(f, ";")?;
+            clause.unparse(s);
+            clause.write_str_break(";", Mandatory);
         }
-        indent(f, cdepth)?;
-        self.tail.unparse(f, cdepth)?;
-
-        if indented {
-            writeln!(f)?;
-            indent(f, depth)?;
-            write!(f, ")")?;
-        }
-        Ok(())
+        self.tail.unparse(s);
     }
 }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -1,6 +1,6 @@
 mod clause;
 
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 pub use self::clause::LetClause;
 
@@ -31,13 +31,13 @@ impl<P, X> LetExpr<P, X> {
     }
 }
 
-impl<P, X> DisplayDepth for LetExpr<P, X>
+impl<P, X> Unparse for LetExpr<P, X>
 where
-    P: DisplayDepth,
-    X: DisplayDepth,
+    P: Unparse,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        use sappho_unparse::indent;
+    fn unparse(&self) -> Stream {
+        use sappho_unparse::{Unparse, Stream};
 
         let (indented, cdepth) = if depth == 0 {
             (false, 0)
@@ -51,11 +51,11 @@ where
 
         for clause in self.clauses.iter() {
             indent(f, cdepth)?;
-            clause.fmt_depth(f, cdepth)?;
+            clause.unparse(f, cdepth)?;
             writeln!(f, ";")?;
         }
         indent(f, cdepth)?;
-        self.tail.fmt_depth(f, cdepth)?;
+        self.tail.unparse(f, cdepth)?;
 
         if indented {
             writeln!(f)?;

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -40,9 +40,10 @@ where
         use sappho_unparse::Break::Mandatory;
 
         for clause in self.clauses.iter() {
-            clause.unparse(s);
-            clause.write_str_break(";", Mandatory);
+            s.write(clause);
+            s.write(";");
+            s.write(Mandatory);
         }
-        self.tail.unparse(s);
+        s.write(self.tail);
     }
 }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -40,15 +40,15 @@ where
         use sappho_unparse::Break::Mandatory;
 
         s.write(&"(");
-        let mut subs = Stream::new();
-        for clause in self.clauses.iter() {
+        s.substream(|subs| {
+            for clause in self.clauses.iter() {
+                subs.write(&Mandatory);
+                subs.write(clause);
+                subs.write(&";");
+            }
             subs.write(&Mandatory);
-            subs.write(clause);
-            subs.write(&";");
-        }
-        subs.write(&Mandatory);
-        subs.write(&self.tail);
-        s.add_substream(subs);
+            subs.write(&self.tail);
+        });
         s.write(&Mandatory);
         s.write(&")");
     }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -39,17 +39,25 @@ where
     fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::Break::Mandatory;
 
-        s.write(&"(");
-        s.substream(|subs| {
+        let unparse_clauses = |s: &mut Stream| {
             for clause in self.clauses.iter() {
-                subs.write(&Mandatory);
-                subs.write(clause);
-                subs.write(&";");
+                if s.depth() > 0 {
+                    s.write(&Mandatory);
+                }
+                s.write(clause);
+                s.write(&";");
             }
-            subs.write(&Mandatory);
-            subs.write(&self.tail);
-        });
-        s.write(&Mandatory);
-        s.write(&")");
+            s.write(&Mandatory);
+            s.write(&self.tail);
+        };
+
+        if s.depth() == 0 {
+            unparse_clauses(s);
+        } else {
+            s.write(&"(");
+            s.substream(unparse_clauses);
+            s.write(&Mandatory);
+            s.write(&")");
+        }
     }
 }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -39,11 +39,17 @@ where
     fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::Break::Mandatory;
 
+        s.write(&"(");
+        let mut subs = Stream::new();
         for clause in self.clauses.iter() {
-            s.write(clause);
-            s.write(&";");
-            s.write(&Mandatory);
+            subs.write(&Mandatory);
+            subs.write(clause);
+            subs.write(&";");
         }
-        s.write(&self.tail);
+        subs.write(&Mandatory);
+        subs.write(&self.tail);
+        s.add_substream(subs);
+        s.write(&Mandatory);
+        s.write(&")");
     }
 }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -42,7 +42,7 @@ where
         for clause in self.clauses.iter() {
             s.write(clause);
             s.write(&";");
-            s.write(Mandatory);
+            s.write(&Mandatory);
         }
         s.write(self.tail);
     }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -36,7 +36,7 @@ where
     P: Unparse,
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::{Unparse, Stream};
 
         let (indented, cdepth) = if depth == 0 {

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -41,7 +41,7 @@ where
 
         for clause in self.clauses.iter() {
             s.write(clause);
-            s.write(";");
+            s.write(&";");
             s.write(Mandatory);
         }
         s.write(self.tail);

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -44,6 +44,6 @@ where
             s.write(&";");
             s.write(&Mandatory);
         }
-        s.write(self.tail);
+        s.write(&self.tail);
     }
 }

--- a/gast/src/letexpr.rs
+++ b/gast/src/letexpr.rs
@@ -40,8 +40,8 @@ where
         use sappho_unparse::Break::Mandatory;
 
         let unparse_clauses = |s: &mut Stream| {
-            for clause in self.clauses.iter() {
-                if s.depth() > 0 {
+            for (ix, clause) in self.clauses.iter().enumerate() {
+                if s.depth() > 0 || ix > 0 {
                     s.write(&Mandatory);
                 }
                 s.write(clause);

--- a/gast/src/letexpr/clause.rs
+++ b/gast/src/letexpr/clause.rs
@@ -28,9 +28,9 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write("let ");
+        s.write(&"let ");
         s.write(self.binding);
-        s.write(" = ");
+        s.write(&" = ");
         s.write(self.bindexpr);
     }
 }

--- a/gast/src/letexpr/clause.rs
+++ b/gast/src/letexpr/clause.rs
@@ -29,8 +29,8 @@ where
 {
     fn unparse_into(&self, s: &mut Stream) {
         s.write(&"let ");
-        s.write(self.binding);
+        s.write(&self.binding);
         s.write(&" = ");
-        s.write(self.bindexpr);
+        s.write(&self.bindexpr);
     }
 }

--- a/gast/src/letexpr/clause.rs
+++ b/gast/src/letexpr/clause.rs
@@ -28,9 +28,9 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write_str("let ");
-        self.binding.unparse(s);
-        s.write_str(" = ");
-        self.bindexpr.unparse(s);
+        s.write("let ");
+        s.write(self.binding);
+        s.write(" = ");
+        s.write(self.bindexpr);
     }
 }

--- a/gast/src/letexpr/clause.rs
+++ b/gast/src/letexpr/clause.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
 pub struct LetClause<Pattern, Expr> {
@@ -22,16 +22,16 @@ impl<P, X> LetClause<P, X> {
     }
 }
 
-impl<P, X> DisplayDepth for LetClause<P, X>
+impl<P, X> Unparse for LetClause<P, X>
 where
-    P: DisplayDepth,
-    X: DisplayDepth,
+    P: Unparse,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+    fn unparse(&self) -> Stream {
         write!(f, "let ")?;
-        self.binding.fmt_depth(f, depth)?;
+        self.binding.unparse(f, depth)?;
         write!(f, " = ")?;
-        self.bindexpr.fmt_depth(f, depth)?;
+        self.bindexpr.unparse(f, depth)?;
         Ok(())
     }
 }

--- a/gast/src/letexpr/clause.rs
+++ b/gast/src/letexpr/clause.rs
@@ -27,7 +27,7 @@ where
     P: Unparse,
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         write!(f, "let ")?;
         self.binding.unparse(f, depth)?;
         write!(f, " = ")?;

--- a/gast/src/letexpr/clause.rs
+++ b/gast/src/letexpr/clause.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
 pub struct LetClause<Pattern, Expr> {
@@ -28,10 +28,9 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        write!(f, "let ")?;
-        self.binding.unparse(f, depth)?;
-        write!(f, " = ")?;
-        self.bindexpr.unparse(f, depth)?;
-        Ok(())
+        s.write_str("let ");
+        self.binding.unparse(s);
+        s.write_str(" = ");
+        self.bindexpr.unparse(s);
     }
 }

--- a/gast/src/literal.rs
+++ b/gast/src/literal.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// A literal value, such as `3.1415`.
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
@@ -7,8 +7,8 @@ pub enum Literal {
     Num(f64),
 }
 
-impl DisplayDepth for Literal {
-    fn fmt_depth(&self, f: &mut Formatter, _depth: usize) -> FmtResult {
+impl Unparse for Literal {
+    fn unparse(&self) -> Stream {
         use std::fmt::Display;
         use Literal::*;
 

--- a/gast/src/literal.rs
+++ b/gast/src/literal.rs
@@ -9,11 +9,10 @@ pub enum Literal {
 
 impl Unparse for Literal {
     fn unparse_into(&self, s: &mut Stream) {
-        use std::fmt::Display;
         use Literal::*;
 
         match self {
-            Num(x) => s.write_string(x.to_string()),
+            Num(x) => s.write(x.to_string()),
         }
     }
 }

--- a/gast/src/literal.rs
+++ b/gast/src/literal.rs
@@ -8,7 +8,7 @@ pub enum Literal {
 }
 
 impl Unparse for Literal {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use std::fmt::Display;
         use Literal::*;
 

--- a/gast/src/literal.rs
+++ b/gast/src/literal.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// A literal value, such as `3.1415`.
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
@@ -13,7 +13,7 @@ impl Unparse for Literal {
         use Literal::*;
 
         match self {
-            Num(x) => x.fmt(f),
+            Num(x) => s.write_string(x.to_string()),
         }
     }
 }

--- a/gast/src/literal.rs
+++ b/gast/src/literal.rs
@@ -12,7 +12,7 @@ impl Unparse for Literal {
         use Literal::*;
 
         match self {
-            Num(x) => s.write(x.to_string()),
+            Num(x) => s.write(&x.to_string()),
         }
     }
 }

--- a/gast/src/lookup.rs
+++ b/gast/src/lookup.rs
@@ -1,5 +1,5 @@
 use crate::Identifier;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// An attribute lookup expression, ie: `x.foo`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -23,12 +23,12 @@ impl<X> LookupExpr<X> {
     }
 }
 
-impl<X> DisplayDepth for LookupExpr<X>
+impl<X> Unparse for LookupExpr<X>
 where
-    X: DisplayDepth,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.target.fmt_depth(f, depth)?;
+    fn unparse(&self) -> Stream {
+        self.target.unparse(f, depth)?;
         write!(f, ".{}", self.attr)?;
         Ok(())
     }

--- a/gast/src/lookup.rs
+++ b/gast/src/lookup.rs
@@ -28,8 +28,8 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write(self.target);
+        s.write(&self.target);
         s.write(&".");
-        s.write(self.attr);
+        s.write(&self.attr);
     }
 }

--- a/gast/src/lookup.rs
+++ b/gast/src/lookup.rs
@@ -1,5 +1,5 @@
 use crate::Identifier;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// An attribute lookup expression, ie: `x.foo`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -28,8 +28,8 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        self.target.unparse(f, depth)?;
-        write!(f, ".{}", self.attr)?;
-        Ok(())
+        self.target.unparse(s);
+        s.write_str(".");
+        s.write_str(self.attr);
     }
 }

--- a/gast/src/lookup.rs
+++ b/gast/src/lookup.rs
@@ -28,8 +28,8 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        self.target.unparse(s);
-        s.write_str(".");
-        s.write_str(self.attr);
+        s.write(self.target);
+        s.write(".");
+        s.write(self.attr);
     }
 }

--- a/gast/src/lookup.rs
+++ b/gast/src/lookup.rs
@@ -29,7 +29,7 @@ where
 {
     fn unparse_into(&self, s: &mut Stream) {
         s.write(self.target);
-        s.write(".");
+        s.write(&".");
         s.write(self.attr);
     }
 }

--- a/gast/src/lookup.rs
+++ b/gast/src/lookup.rs
@@ -27,7 +27,7 @@ impl<X> Unparse for LookupExpr<X>
 where
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.target.unparse(f, depth)?;
         write!(f, ".{}", self.attr)?;
         Ok(())

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -39,16 +39,16 @@ where
     fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::Break::OptSpace;
 
-        s.write("match ");
+        s.write(&"match ");
         s.write(self.target);
-        s.write(" {");
+        s.write(&" {");
         let mut subs = Stream::new();
         for clause in &self.clauses {
             subs.write(clause);
-            subs.write(",");
+            subs.write(&",");
             subs.write(OptSpace);
         }
         s.add_substream(subs);
-        s.write("}");
+        s.write(&"}");
     }
 }

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -36,7 +36,7 @@ where
     P: Unparse,
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::{Unparse, Stream};
 
         write!(f, "match ")?;

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -42,13 +42,13 @@ where
         s.write(&"match ");
         s.write(&self.target);
         s.write(&" {");
-        let mut subs = Stream::new();
-        for clause in &self.clauses {
-            subs.write(&OptSpace);
-            subs.write(clause);
-            subs.write(&",");
-        }
-        s.add_substream(subs);
+        s.substream(|subs| {
+            for clause in &self.clauses {
+                subs.write(&OptSpace);
+                subs.write(clause);
+                subs.write(&",");
+            }
+        });
         s.write(&OptSpace);
         s.write(&"}");
     }

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -37,15 +37,18 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write_str("match ");
-        self.target.unparse(s);
-        s.write_str(" {");
+        use sappho_unparse::Break::OptSpace;
+
+        s.write("match ");
+        s.write(self.target);
+        s.write(" {");
         let mut subs = Stream::new();
         for clause in &self.clauses {
-            clause.unparse(&mut subs);
-            subs.write_str_break(",", true);
+            subs.write(clause);
+            subs.write(",");
+            subs.write(OptSpace);
         }
         s.add_substream(subs);
-        s.write_str("}");
+        s.write("}");
     }
 }

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -1,6 +1,6 @@
 mod clause;
 
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 pub use self::clause::MatchClause;
 
@@ -31,20 +31,20 @@ impl<P, X> MatchExpr<P, X> {
     }
 }
 
-impl<P, X> DisplayDepth for MatchExpr<P, X>
+impl<P, X> Unparse for MatchExpr<P, X>
 where
-    P: DisplayDepth,
-    X: DisplayDepth,
+    P: Unparse,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        use sappho_unparse::indent;
+    fn unparse(&self) -> Stream {
+        use sappho_unparse::{Unparse, Stream};
 
         write!(f, "match ")?;
-        self.target.fmt_depth(f, depth)?;
+        self.target.unparse(f, depth)?;
         writeln!(f, " {{")?;
         for clause in &self.clauses {
             indent(f, depth + 1)?;
-            clause.fmt_depth(f, depth + 1)?;
+            clause.unparse(f, depth + 1)?;
             writeln!(f, ",")?;
         }
         indent(f, depth)?;

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -40,7 +40,7 @@ where
         use sappho_unparse::Break::OptSpace;
 
         s.write(&"match ");
-        s.write(self.target);
+        s.write(&self.target);
         s.write(&" {");
         let mut subs = Stream::new();
         for clause in &self.clauses {

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -44,11 +44,12 @@ where
         s.write(&" {");
         let mut subs = Stream::new();
         for clause in &self.clauses {
+            subs.write(&OptSpace);
             subs.write(clause);
             subs.write(&",");
-            subs.write(&OptSpace);
         }
         s.add_substream(subs);
+        s.write(&OptSpace);
         s.write(&"}");
     }
 }

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -1,6 +1,6 @@
 mod clause;
 
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 pub use self::clause::MatchClause;
 
@@ -37,18 +37,15 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        use sappho_unparse::{Unparse, Stream};
-
-        write!(f, "match ")?;
-        self.target.unparse(f, depth)?;
-        writeln!(f, " {{")?;
+        s.write_str("match ");
+        self.target.unparse(s);
+        s.write_str(" {");
+        let mut subs = Stream::new();
         for clause in &self.clauses {
-            indent(f, depth + 1)?;
-            clause.unparse(f, depth + 1)?;
-            writeln!(f, ",")?;
+            clause.unparse(&mut subs);
+            subs.write_str_break(",", true);
         }
-        indent(f, depth)?;
-        write!(f, "}}")?;
-        Ok(())
+        s.add_substream(subs);
+        s.write_str("}");
     }
 }

--- a/gast/src/matchexpr.rs
+++ b/gast/src/matchexpr.rs
@@ -46,7 +46,7 @@ where
         for clause in &self.clauses {
             subs.write(clause);
             subs.write(&",");
-            subs.write(OptSpace);
+            subs.write(&OptSpace);
         }
         s.add_substream(subs);
         s.write(&"}");

--- a/gast/src/matchexpr/clause.rs
+++ b/gast/src/matchexpr/clause.rs
@@ -29,8 +29,8 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        self.pattern.unparse(s);
-        s.write_str(" -> ");
-        self.body.unparse(s);
+        s.write(self.pattern);
+        s.write(" -> ");
+        s.write(self.body);
     }
 }

--- a/gast/src/matchexpr/clause.rs
+++ b/gast/src/matchexpr/clause.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// A `match` clause, ie `3 -> 0` and `y -> y` in `match x { 3 -> 0, y -> y }`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -29,9 +29,8 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        self.pattern.unparse(f, depth)?;
-        write!(f, " -> ")?;
-        self.body.unparse(f, depth)?;
-        Ok(())
+        self.pattern.unparse(s);
+        s.write_str(" -> ");
+        self.body.unparse(s);
     }
 }

--- a/gast/src/matchexpr/clause.rs
+++ b/gast/src/matchexpr/clause.rs
@@ -29,8 +29,8 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write(self.pattern);
+        s.write(&self.pattern);
         s.write(&" -> ");
-        s.write(self.body);
+        s.write(&self.body);
     }
 }

--- a/gast/src/matchexpr/clause.rs
+++ b/gast/src/matchexpr/clause.rs
@@ -30,7 +30,7 @@ where
 {
     fn unparse_into(&self, s: &mut Stream) {
         s.write(self.pattern);
-        s.write(" -> ");
+        s.write(&" -> ");
         s.write(self.body);
     }
 }

--- a/gast/src/matchexpr/clause.rs
+++ b/gast/src/matchexpr/clause.rs
@@ -28,7 +28,7 @@ where
     P: Unparse,
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.pattern.unparse(f, depth)?;
         write!(f, " -> ")?;
         self.body.unparse(f, depth)?;

--- a/gast/src/matchexpr/clause.rs
+++ b/gast/src/matchexpr/clause.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// A `match` clause, ie `3 -> 0` and `y -> y` in `match x { 3 -> 0, y -> y }`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -23,15 +23,15 @@ impl<P, X> MatchClause<P, X> {
     }
 }
 
-impl<P, X> DisplayDepth for MatchClause<P, X>
+impl<P, X> Unparse for MatchClause<P, X>
 where
-    P: DisplayDepth,
-    X: DisplayDepth,
+    P: Unparse,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.pattern.fmt_depth(f, depth)?;
+    fn unparse(&self) -> Stream {
+        self.pattern.unparse(f, depth)?;
         write!(f, " -> ")?;
-        self.body.fmt_depth(f, depth)?;
+        self.body.unparse(f, depth)?;
         Ok(())
     }
 }

--- a/gast/src/object.rs
+++ b/gast/src/object.rs
@@ -1,7 +1,7 @@
 use crate::{FuncDef, QueryDef};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use sappho_object::Object;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// An object definition expression, ie `{ x: 42, y: 7, fn x -> x }`.
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
@@ -97,14 +97,14 @@ impl<P, X, Q, G> TryIntoIdentMap<G> for ObjectDef<P, X, Q, G> {
     }
 }
 
-impl<P, X, Q, G> DisplayDepth for ObjectDef<P, X, Q, G>
+impl<P, X, Q, G> Unparse for ObjectDef<P, X, Q, G>
 where
-    P: DisplayDepth,
-    X: DisplayDepth,
-    Q: DisplayDepth,
-    G: DisplayDepth + TryIntoIdentMap<G>,
+    P: Unparse,
+    X: Unparse,
+    Q: Unparse,
+    G: Unparse + TryIntoIdentMap<G>,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.0.fmt_depth(f, depth)
+    fn unparse(&self) -> Stream {
+        self.0.unparse(f, depth)
     }
 }

--- a/gast/src/object.rs
+++ b/gast/src/object.rs
@@ -1,7 +1,7 @@
 use crate::{FuncDef, QueryDef};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use sappho_object::Object;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// An object definition expression, ie `{ x: 42, y: 7, fn x -> x }`.
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
@@ -105,6 +105,6 @@ where
     G: Unparse + TryIntoIdentMap<G>,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        self.0.unparse(f, depth)
+        self.0.unparse_into(s)
     }
 }

--- a/gast/src/object.rs
+++ b/gast/src/object.rs
@@ -104,7 +104,7 @@ where
     Q: Unparse,
     G: Unparse + TryIntoIdentMap<G>,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.0.unparse(f, depth)
     }
 }

--- a/gast/src/query.rs
+++ b/gast/src/query.rs
@@ -23,7 +23,7 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write("query ");
+        s.write(&"query ");
         s.write(self.body);
     }
 }

--- a/gast/src/query.rs
+++ b/gast/src/query.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 /// A query definition, ie `query $x`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -23,8 +23,7 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        write!(f, "query ")?;
-        self.body.unparse(f, depth)?;
-        Ok(())
+        s.write_str("query ");
+        self.body.unparse(s)
     }
 }

--- a/gast/src/query.rs
+++ b/gast/src/query.rs
@@ -23,7 +23,7 @@ where
     X: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write_str("query ");
-        self.body.unparse(s)
+        s.write("query ");
+        s.write(self.body);
     }
 }

--- a/gast/src/query.rs
+++ b/gast/src/query.rs
@@ -24,6 +24,6 @@ where
 {
     fn unparse_into(&self, s: &mut Stream) {
         s.write(&"query ");
-        s.write(self.body);
+        s.write(&self.body);
     }
 }

--- a/gast/src/query.rs
+++ b/gast/src/query.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// A query definition, ie `query $x`.
 #[derive(Clone, Debug, PartialEq, derive_new::new)]
@@ -18,13 +18,13 @@ impl<X> QueryDef<X> {
     }
 }
 
-impl<X> DisplayDepth for QueryDef<X>
+impl<X> Unparse for QueryDef<X>
 where
-    X: DisplayDepth,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+    fn unparse(&self) -> Stream {
         write!(f, "query ")?;
-        self.body.fmt_depth(f, depth)?;
+        self.body.unparse(f, depth)?;
         Ok(())
     }
 }

--- a/gast/src/query.rs
+++ b/gast/src/query.rs
@@ -22,7 +22,7 @@ impl<X> Unparse for QueryDef<X>
 where
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         write!(f, "query ")?;
         self.body.unparse(f, depth)?;
         Ok(())

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -5,7 +5,7 @@ mod tryinto;
 pub use self::tryinto::TryIntoIdentMap;
 
 use sappho_listform::ListForm;
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 use std::collections::BTreeMap;
 
 pub type Identifier = String;
@@ -149,20 +149,21 @@ where
     T: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        use sappho_unparse::{Unparse, Stream};
+        use sappho_unparse::{Stream, Unparse};
 
         if self.0.is_empty() {
-            write!(f, "{{}}")
+            s.write_str("{}");
         } else {
-            writeln!(f, "{{")?;
+            s.write_str("{");
+            let mut subs = Stream::new();
             for (k, v) in &self.0 {
-                indent(f, depth + 1)?;
-                write!(f, "{}: ", k)?;
-                v.unparse(f, depth + 1)?;
-                writeln!(f, ",")?;
+                subs.write_str(k);
+                subs.write_str(": ");
+                v.unparse_into(&mut subs);
+                subs.write_str_break(",", OptSpace);
             }
-            indent(f, depth)?;
-            write!(f, "}}")
+            s.add_substream(subs);
+            s.write_str("}");
         }
     }
 }

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -149,21 +149,22 @@ where
     T: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        use sappho_unparse::{Stream, Unparse};
+        use sappho_unparse::Break::OptSpace;
 
         if self.0.is_empty() {
-            s.write_str("{}");
+            s.write("{}");
         } else {
-            s.write_str("{");
+            s.write("{");
             let mut subs = Stream::new();
             for (k, v) in &self.0 {
-                subs.write_str(k);
-                subs.write_str(": ");
-                v.unparse_into(&mut subs);
-                subs.write_str_break(",", OptSpace);
+                subs.write(k);
+                subs.write(": ");
+                subs.write(v);
+                subs.write(",");
+                subs.write(OptSpace);
             }
             s.add_substream(subs);
-            s.write_str("}");
+            s.write("}");
         }
     }
 }

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -161,7 +161,7 @@ where
                 subs.write(&": ");
                 subs.write(v);
                 subs.write(&",");
-                subs.write(OptSpace);
+                subs.write(&OptSpace);
             }
             s.add_substream(subs);
             s.write(&"}");

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -157,13 +157,14 @@ where
             s.write(&"{");
             let mut subs = Stream::new();
             for (k, v) in &self.0 {
+                subs.write(&OptSpace);
                 subs.write(k);
                 subs.write(&": ");
                 subs.write(v);
                 subs.write(&",");
-                subs.write(&OptSpace);
             }
             s.add_substream(subs);
+            s.write(&OptSpace);
             s.write(&"}");
         }
     }

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -155,15 +155,15 @@ where
             s.write(&"{}");
         } else {
             s.write(&"{");
-            let mut subs = Stream::new();
-            for (k, v) in &self.0 {
-                subs.write(&OptSpace);
-                subs.write(k);
-                subs.write(&": ");
-                subs.write(v);
-                subs.write(&",");
-            }
-            s.add_substream(subs);
+            s.substream(|subs| {
+                for (k, v) in &self.0 {
+                    subs.write(&OptSpace);
+                    subs.write(k);
+                    subs.write(&": ");
+                    subs.write(v);
+                    subs.write(&",");
+                }
+            });
             s.write(&OptSpace);
             s.write(&"}");
         }

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -5,7 +5,7 @@ mod tryinto;
 pub use self::tryinto::TryIntoIdentMap;
 
 use sappho_listform::ListForm;
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 use std::collections::BTreeMap;
 
 pub type Identifier = String;
@@ -144,12 +144,12 @@ impl<T> IntoIterator for IdentMap<T> {
     }
 }
 
-impl<T> DisplayDepth for IdentMap<T>
+impl<T> Unparse for IdentMap<T>
 where
-    T: DisplayDepth,
+    T: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        use sappho_unparse::indent;
+    fn unparse(&self) -> Stream {
+        use sappho_unparse::{Unparse, Stream};
 
         if self.0.is_empty() {
             write!(f, "{{}}")
@@ -158,7 +158,7 @@ where
             for (k, v) in &self.0 {
                 indent(f, depth + 1)?;
                 write!(f, "{}: ", k)?;
-                v.fmt_depth(f, depth + 1)?;
+                v.unparse(f, depth + 1)?;
                 writeln!(f, ",")?;
             }
             indent(f, depth)?;

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -148,7 +148,7 @@ impl<T> Unparse for IdentMap<T>
 where
     T: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::{Unparse, Stream};
 
         if self.0.is_empty() {

--- a/identmap/src/lib.rs
+++ b/identmap/src/lib.rs
@@ -152,19 +152,19 @@ where
         use sappho_unparse::Break::OptSpace;
 
         if self.0.is_empty() {
-            s.write("{}");
+            s.write(&"{}");
         } else {
-            s.write("{");
+            s.write(&"{");
             let mut subs = Stream::new();
             for (k, v) in &self.0 {
                 subs.write(k);
-                subs.write(": ");
+                subs.write(&": ");
                 subs.write(v);
-                subs.write(",");
+                subs.write(&",");
                 subs.write(OptSpace);
             }
             s.add_substream(subs);
-            s.write("}");
+            s.write(&"}");
         }
     }
 }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -79,7 +79,7 @@ where
     X: Unparse,
     T: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::{Unparse, Stream};
 
         if self.is_empty() {
@@ -134,7 +134,7 @@ mod tests {
     struct X;
 
     impl Unparse for X {
-        fn unparse(&self) -> Stream {
+        fn unparse_into(&self, s: &mut Stream) {
             write!(f, "X")
         }
     }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -89,23 +89,22 @@ where
             let mut first = true;
 
             s.write(&"[");
-            s.write(&Opt);
             let mut subs = Stream::new();
             for elem in self.body.iter() {
                 if first {
                     first = false;
                 } else {
                     subs.write(&",");
-                    subs.write(&OptSpace);
                 }
+                subs.write(&OptSpace);
                 subs.write(elem);
             }
 
             if let Some(tail) = &self.tail {
                 if !first {
                     subs.write(&",");
-                    subs.write(&OptSpace);
                 }
+                subs.write(&OptSpace);
                 subs.write(&"..");
                 subs.write(tail);
             }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -84,18 +84,18 @@ where
         use sappho_unparse::Break::{Opt, OptSpace};
 
         if self.is_empty() {
-            s.write("[]")
+            s.write(&"[]")
         } else {
             let mut first = true;
 
-            s.write("[");
+            s.write(&"[");
             s.write(Opt);
             let mut subs = Stream::new();
             for elem in self.body.iter() {
                 if first {
                     first = false;
                 } else {
-                    subs.write(",");
+                    subs.write(&",");
                     subs.write(OptSpace);
                 }
                 subs.write(elem);
@@ -103,15 +103,15 @@ where
 
             if let Some(tail) = &self.tail {
                 if !first {
-                    subs.write(",");
+                    subs.write(&",");
                     subs.write(OptSpace);
                 }
-                subs.write("..");
+                subs.write(&"..");
                 subs.write(tail);
             }
             s.add_substream(subs);
             s.write(Opt);
-            s.write("]");
+            s.write(&"]");
         }
     }
 }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -89,26 +89,26 @@ where
             let mut first = true;
 
             s.write(&"[");
-            let mut subs = Stream::new();
-            for elem in self.body.iter() {
-                if first {
-                    first = false;
-                } else {
-                    subs.write(&",");
+            s.substream(|subs| {
+                for elem in self.body.iter() {
+                    if first {
+                        first = false;
+                    } else {
+                        subs.write(&",");
+                    }
+                    subs.write(&OptSpace);
+                    subs.write(elem);
                 }
-                subs.write(&OptSpace);
-                subs.write(elem);
-            }
 
-            if let Some(tail) = &self.tail {
-                if !first {
-                    subs.write(&",");
+                if let Some(tail) = &self.tail {
+                    if !first {
+                        subs.write(&",");
+                    }
+                    subs.write(&OptSpace);
+                    subs.write(&"..");
+                    subs.write(tail);
                 }
-                subs.write(&OptSpace);
-                subs.write(&"..");
-                subs.write(tail);
-            }
-            s.add_substream(subs);
+            });
             s.write(&Opt);
             s.write(&"]");
         }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -1,4 +1,5 @@
 use sappho_unparse::{Stream, Unparse};
+use std::fmt;
 
 /// A general structure for a sequence of items, with an optional tail, used for both list patterns
 /// and expressions in the ast, examples: `[]`, `[32]`, `[a, b, ..t]`
@@ -80,45 +81,47 @@ where
     T: Unparse,
 {
     fn unparse_into(&self, s: &mut Stream) {
-        use sappho_unparse::{Stream, Unparse};
+        use sappho_unparse::Break::{Opt, OptSpace};
 
         if self.is_empty() {
-            s.write_str("[]")
+            s.write("[]")
         } else {
             let mut first = true;
 
-            s.write_str_break("[", true);
+            s.write("[");
+            s.write(Opt);
             let mut subs = Stream::new();
             for elem in self.body.iter() {
                 if first {
                     first = false;
                 } else {
-                    subs.write_str_break(",", true);
+                    subs.write(",");
+                    subs.write(OptSpace);
                 }
-                elem.unparse_into(&mut subs);
+                subs.write(elem);
             }
 
             if let Some(tail) = &self.tail {
                 if !first {
-                    subs.write_str_break(",", true);
+                    subs.write(",");
+                    subs.write(OptSpace);
                 }
-                subs.write_str("..");
-                tail.unparse(&mut subs);
+                subs.write("..");
+                subs.write(tail);
             }
             s.add_substream(subs);
-            s.add_break(true);
-            s.write_str("]");
-            s
+            s.write(Opt);
+            s.write("]");
         }
     }
 }
 
-impl<X, T> std::fmt::Display for ListForm<X, T>
+impl<X, T> fmt::Display for ListForm<X, T>
 where
     X: Unparse,
     T: Unparse,
 {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.unparse().fmt(f)
     }
 }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -1,4 +1,4 @@
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 /// A general structure for a sequence of items, with an optional tail, used for both list patterns
 /// and expressions in the ast, examples: `[]`, `[32]`, `[a, b, ..t]`
@@ -74,13 +74,13 @@ impl<X, T, E> ListForm<X, Result<T, E>> {
     }
 }
 
-impl<X, T> DisplayDepth for ListForm<X, T>
+impl<X, T> Unparse for ListForm<X, T>
 where
-    X: DisplayDepth,
-    T: DisplayDepth,
+    X: Unparse,
+    T: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        use sappho_unparse::indent;
+    fn unparse(&self) -> Stream {
+        use sappho_unparse::{Unparse, Stream};
 
         if self.is_empty() {
             write!(f, "[]")
@@ -95,7 +95,7 @@ where
                     writeln!(f, ",")?;
                 }
                 indent(f, depth + 1)?;
-                elem.fmt_depth(f, depth + 1)?;
+                elem.unparse(f, depth + 1)?;
             }
 
             if let Some(tail) = &self.tail {
@@ -104,7 +104,7 @@ where
                 }
                 indent(f, depth + 1)?;
                 write!(f, "..")?;
-                tail.fmt_depth(f, depth + 1)?;
+                tail.unparse(f, depth + 1)?;
             }
             writeln!(f)?;
             indent(f, depth)?;
@@ -116,11 +116,11 @@ where
 
 impl<X, T> std::fmt::Display for ListForm<X, T>
 where
-    X: DisplayDepth,
-    T: DisplayDepth,
+    X: Unparse,
+    T: Unparse,
 {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.fmt_depth(f, 0)
+        self.unparse(f, 0)
     }
 }
 
@@ -128,13 +128,13 @@ where
 mod tests {
     use crate::ListForm;
     use indoc::indoc;
-    use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+    use sappho_unparse::{Unparse, Stream};
     use test_case::test_case;
 
     struct X;
 
-    impl DisplayDepth for X {
-        fn fmt_depth(&self, f: &mut Formatter, _depth: usize) -> FmtResult {
+    impl Unparse for X {
+        fn unparse(&self) -> Stream {
             write!(f, "X")
         }
     }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -89,14 +89,14 @@ where
             let mut first = true;
 
             s.write(&"[");
-            s.write(Opt);
+            s.write(&Opt);
             let mut subs = Stream::new();
             for elem in self.body.iter() {
                 if first {
                     first = false;
                 } else {
                     subs.write(&",");
-                    subs.write(OptSpace);
+                    subs.write(&OptSpace);
                 }
                 subs.write(elem);
             }
@@ -104,13 +104,13 @@ where
             if let Some(tail) = &self.tail {
                 if !first {
                     subs.write(&",");
-                    subs.write(OptSpace);
+                    subs.write(&OptSpace);
                 }
                 subs.write(&"..");
                 subs.write(tail);
             }
             s.add_substream(subs);
-            s.write(Opt);
+            s.write(&Opt);
             s.write(&"]");
         }
     }

--- a/listform/src/lib.rs
+++ b/listform/src/lib.rs
@@ -137,7 +137,7 @@ mod tests {
 
     impl Unparse for X {
         fn unparse_into(&self, s: &mut Stream) {
-            write!(f, "X")
+            s.write(&"X");
         }
     }
 

--- a/object/src/object.rs
+++ b/object/src/object.rs
@@ -128,28 +128,30 @@ where
             s.write(&"{}");
         } else {
             s.write(&"{");
+
             let mut subs = Stream::new();
             if let Some(func) = self.func() {
+                subs.write(&OptSpace);
                 subs.write(func);
                 subs.write(&",");
-                subs.write(&OptSpace);
             }
 
             if let Some(query) = self.query() {
+                subs.write(&OptSpace);
                 subs.write(query);
                 subs.write(&",");
-                subs.write(&OptSpace);
             }
 
             for (name, attr) in self.attrs().iter() {
+                subs.write(&OptSpace);
                 subs.write(name);
                 subs.write(&": ");
                 subs.write(attr);
                 subs.write(&",");
-                subs.write(&OptSpace);
             }
 
             s.add_substream(subs);
+            s.write(&OptSpace);
             s.write(&"}");
         }
     }

--- a/object/src/object.rs
+++ b/object/src/object.rs
@@ -132,13 +132,13 @@ where
             if let Some(func) = self.func() {
                 subs.write(func);
                 subs.write(&",");
-                subs.write(OptSpace);
+                subs.write(&OptSpace);
             }
 
             if let Some(query) = self.query() {
                 subs.write(query);
                 subs.write(&",");
-                subs.write(OptSpace);
+                subs.write(&OptSpace);
             }
 
             for (name, attr) in self.attrs().iter() {
@@ -146,7 +146,7 @@ where
                 subs.write(&": ");
                 subs.write(attr);
                 subs.write(&",");
-                subs.write(OptSpace);
+                subs.write(&OptSpace);
             }
 
             s.add_substream(subs);

--- a/object/src/object.rs
+++ b/object/src/object.rs
@@ -121,7 +121,7 @@ where
     Q: Unparse,
     A: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use sappho_unparse::{Unparse, Stream};
 
         if self.is_empty() {

--- a/object/src/object.rs
+++ b/object/src/object.rs
@@ -125,32 +125,32 @@ where
         use sappho_unparse::Break::OptSpace;
 
         if self.is_empty() {
-            s.write("{}");
+            s.write(&"{}");
         } else {
-            s.write("{");
+            s.write(&"{");
             let mut subs = Stream::new();
             if let Some(func) = self.func() {
                 subs.write(func);
-                subs.write(",");
+                subs.write(&",");
                 subs.write(OptSpace);
             }
 
             if let Some(query) = self.query() {
                 subs.write(query);
-                subs.write(",");
+                subs.write(&",");
                 subs.write(OptSpace);
             }
 
             for (name, attr) in self.attrs().iter() {
                 subs.write(name);
-                subs.write(": ");
+                subs.write(&": ");
                 subs.write(attr);
-                subs.write(",");
+                subs.write(&",");
                 subs.write(OptSpace);
             }
 
             s.add_substream(subs);
-            s.write("}");
+            s.write(&"}");
         }
     }
 }

--- a/object/src/object.rs
+++ b/object/src/object.rs
@@ -128,29 +128,27 @@ where
             s.write(&"{}");
         } else {
             s.write(&"{");
+            s.substream(|subs| {
+                if let Some(func) = self.func() {
+                    subs.write(&OptSpace);
+                    subs.write(func);
+                    subs.write(&",");
+                }
 
-            let mut subs = Stream::new();
-            if let Some(func) = self.func() {
-                subs.write(&OptSpace);
-                subs.write(func);
-                subs.write(&",");
-            }
+                if let Some(query) = self.query() {
+                    subs.write(&OptSpace);
+                    subs.write(query);
+                    subs.write(&",");
+                }
 
-            if let Some(query) = self.query() {
-                subs.write(&OptSpace);
-                subs.write(query);
-                subs.write(&",");
-            }
-
-            for (name, attr) in self.attrs().iter() {
-                subs.write(&OptSpace);
-                subs.write(name);
-                subs.write(&": ");
-                subs.write(attr);
-                subs.write(&",");
-            }
-
-            s.add_substream(subs);
+                for (name, attr) in self.attrs().iter() {
+                    subs.write(&OptSpace);
+                    subs.write(name);
+                    subs.write(&": ");
+                    subs.write(attr);
+                    subs.write(&",");
+                }
+            });
             s.write(&OptSpace);
             s.write(&"}");
         }

--- a/object/src/object.rs
+++ b/object/src/object.rs
@@ -125,29 +125,32 @@ where
         use sappho_unparse::Break::OptSpace;
 
         if self.is_empty() {
-            s.write_str("{}");
+            s.write("{}");
         } else {
-            s.write_str("{");
+            s.write("{");
             let mut subs = Stream::new();
             if let Some(func) = self.func() {
-                func.unparse_into(&mut subs);
-                subs.write_str_break(",", OptSpace);
+                subs.write(func);
+                subs.write(",");
+                subs.write(OptSpace);
             }
 
             if let Some(query) = self.query() {
-                query.unparse_into(&mut subs);
-                subs.write_str_break(",", OptSpace);
+                subs.write(query);
+                subs.write(",");
+                subs.write(OptSpace);
             }
 
             for (name, attr) in self.attrs().iter() {
-                subs.write_str(name);
-                subs.write_str(": ");
-                attr.unparse_into(&mut subs);
-                subs.write_str_break(",", OptSpace);
+                subs.write(name);
+                subs.write(": ");
+                subs.write(attr);
+                subs.write(",");
+                subs.write(OptSpace);
             }
 
             s.add_substream(subs);
-            s.write_str("}");
+            s.write("}");
         }
     }
 }

--- a/object/src/object.rs
+++ b/object/src/object.rs
@@ -1,7 +1,7 @@
 use crate::Unbundled;
 use derive_new::new;
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 #[derive(Clone, Debug, PartialEq, new)]
 pub struct Object<F, Q, A> {
@@ -115,14 +115,14 @@ impl<F, Q, A> TryIntoIdentMap<A> for Object<F, Q, A> {
     }
 }
 
-impl<F, Q, A> DisplayDepth for Object<F, Q, A>
+impl<F, Q, A> Unparse for Object<F, Q, A>
 where
-    F: DisplayDepth,
-    Q: DisplayDepth,
-    A: DisplayDepth,
+    F: Unparse,
+    Q: Unparse,
+    A: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        use sappho_unparse::indent;
+    fn unparse(&self) -> Stream {
+        use sappho_unparse::{Unparse, Stream};
 
         if self.is_empty() {
             return write!(f, "{{}}");
@@ -131,20 +131,20 @@ where
         writeln!(f, "{{")?;
         if let Some(func) = self.func() {
             indent(f, depth + 1)?;
-            func.fmt_depth(f, depth + 1)?;
+            func.unparse(f, depth + 1)?;
             writeln!(f, ",")?;
         }
 
         if let Some(query) = self.query() {
             indent(f, depth + 1)?;
-            query.fmt_depth(f, depth + 1)?;
+            query.unparse(f, depth + 1)?;
             writeln!(f, ",")?;
         }
 
         for (name, attr) in self.attrs().iter() {
             indent(f, depth + 1)?;
             write!(f, "{}: ", name)?;
-            attr.fmt_depth(f, depth + 1)?;
+            attr.unparse(f, depth + 1)?;
             writeln!(f, ",")?;
         }
 

--- a/unparse/src/brk.rs
+++ b/unparse/src/brk.rs
@@ -1,0 +1,6 @@
+#[derive(Debug)]
+pub enum Break {
+    Mandatory,
+    OptSpace,
+    Opt,
+}

--- a/unparse/src/brk.rs
+++ b/unparse/src/brk.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Break {
     Mandatory,
     OptSpace,

--- a/unparse/src/lib.rs
+++ b/unparse/src/lib.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 pub use std::fmt::{Formatter, Result as FmtResult};
 
-pub trait DisplayDepth {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult;
+pub trait Unparse {
+    fn unparse(&self) -> Stream {
 }
 
 pub fn indent(f: &mut Formatter, depth: usize) -> FmtResult {
@@ -12,17 +12,17 @@ pub fn indent(f: &mut Formatter, depth: usize) -> FmtResult {
     Ok(())
 }
 
-impl DisplayDepth for String {
-    fn fmt_depth(&self, f: &mut Formatter, _depth: usize) -> FmtResult {
+impl Unparse for String {
+    fn unparse(&self) -> Stream {
         self.fmt(f)
     }
 }
 
-impl<X> DisplayDepth for Box<X>
+impl<X> Unparse for Box<X>
 where
-    X: DisplayDepth,
+    X: Unparse,
 {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.as_ref().fmt_depth(f, depth)
+    fn unparse(&self) -> Stream {
+        self.as_ref().unparse(f, depth)
     }
 }

--- a/unparse/src/lib.rs
+++ b/unparse/src/lib.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 pub use std::fmt::{Formatter, Result as FmtResult};
 
 pub trait Unparse {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
 }
 
 pub fn indent(f: &mut Formatter, depth: usize) -> FmtResult {
@@ -13,7 +13,7 @@ pub fn indent(f: &mut Formatter, depth: usize) -> FmtResult {
 }
 
 impl Unparse for String {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.fmt(f)
     }
 }
@@ -22,7 +22,7 @@ impl<X> Unparse for Box<X>
 where
     X: Unparse,
 {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.as_ref().unparse(f, depth)
     }
 }

--- a/unparse/src/lib.rs
+++ b/unparse/src/lib.rs
@@ -1,5 +1,7 @@
+mod brk;
 mod stream;
 mod unparse;
 
+pub use self::brk::Break;
 pub use self::stream::Stream;
 pub use self::unparse::Unparse;

--- a/unparse/src/lib.rs
+++ b/unparse/src/lib.rs
@@ -1,28 +1,5 @@
-use std::fmt::Display;
-pub use std::fmt::{Formatter, Result as FmtResult};
+mod stream;
+mod unparse;
 
-pub trait Unparse {
-    fn unparse_into(&self, s: &mut Stream) {
-}
-
-pub fn indent(f: &mut Formatter, depth: usize) -> FmtResult {
-    for _ in 0..depth {
-        write!(f, "  ")?;
-    }
-    Ok(())
-}
-
-impl Unparse for String {
-    fn unparse_into(&self, s: &mut Stream) {
-        self.fmt(f)
-    }
-}
-
-impl<X> Unparse for Box<X>
-where
-    X: Unparse,
-{
-    fn unparse_into(&self, s: &mut Stream) {
-        self.as_ref().unparse(f, depth)
-    }
-}
+pub use self::stream::Stream;
+pub use self::unparse::Unparse;

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -1,12 +1,35 @@
+use crate::Break;
+
+#[derive(Debug, Default)]
+pub struct Stream(Vec<Item>);
+
 #[derive(Debug)]
-pub struct Stream;
+enum Item {
+    Leaf(String),
+    Break(Break),
+    Substream(Stream),
+}
+use Item::*;
 
 impl Stream {
     pub fn new() -> Self {
-        todo!();
+        Self::default()
     }
 
     pub fn write_str(&mut self, s: &str) {
-        todo!("{:?}", s);
+        self.0.push(Leaf(s.to_string()))
+    }
+
+    pub fn write_str_break(&mut self, s: &str, brk: Break) {
+        self.write_str(s);
+        self.add_break(brk);
+    }
+
+    pub fn add_break(&mut self, brk: Break) {
+        self.0.push(Break(brk));
+    }
+
+    pub fn add_substream(&mut self, sub: Stream) {
+        self.0.push(Substream(sub));
     }
 }

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -1,7 +1,11 @@
-#[derive(Debug, derive_new::new)]
+#[derive(Debug)]
 pub struct Stream;
 
 impl Stream {
+    pub fn new() -> Self {
+        todo!();
+    }
+
     pub fn write_str(&mut self, s: &str) {
         todo!();
     }

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, derive_new::new)]
+pub struct Stream;
+
+impl Stream {
+    pub fn write_str(&mut self, s: &str) {
+        todo!();
+    }
+}

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -24,16 +24,16 @@ impl Stream {
         thing.unparse_into(self)
     }
 
-    pub fn write_string(&mut self, s: String) {
+    pub fn add_substream(&mut self, sub: Stream) {
+        self.0.push(Substream(sub));
+    }
+
+    pub(crate) fn write_string(&mut self, s: String) {
         self.0.push(Leaf(s))
     }
 
-    pub fn add_break(&mut self, brk: Break) {
+    pub(crate) fn add_break(&mut self, brk: Break) {
         self.0.push(Break(brk));
-    }
-
-    pub fn add_substream(&mut self, sub: Stream) {
-        self.0.push(Substream(sub));
     }
 }
 

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -7,6 +7,6 @@ impl Stream {
     }
 
     pub fn write_str(&mut self, s: &str) {
-        todo!();
+        todo!("{:?}", s);
     }
 }

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -3,7 +3,10 @@ mod display;
 use crate::{Break, Unparse};
 
 #[derive(Debug)]
-pub struct Stream(Vec<Item>);
+pub struct Stream {
+    items: Vec<Item>,
+    depth: usize,
+}
 
 #[derive(Debug)]
 enum Item {
@@ -14,6 +17,10 @@ enum Item {
 use Item::*;
 
 impl Stream {
+    pub fn depth(&self) -> usize {
+        self.depth
+    }
+
     pub fn write<U>(&mut self, thing: &U)
     where
         U: Unparse,
@@ -25,20 +32,26 @@ impl Stream {
     where
         F: FnOnce(&mut Stream),
     {
-        let mut sub = Stream::new();
+        let mut sub = Stream {
+            items: vec![],
+            depth: self.depth + 1,
+        };
         f(&mut sub);
-        self.0.push(Substream(sub));
+        self.items.push(Substream(sub));
     }
 
     pub(crate) fn new() -> Self {
-        Stream(vec![])
+        Stream {
+            items: vec![],
+            depth: 0,
+        }
     }
 
     pub(crate) fn write_string(&mut self, s: String) {
-        self.0.push(Leaf(s))
+        self.items.push(Leaf(s))
     }
 
     pub(crate) fn add_break(&mut self, brk: Break) {
-        self.0.push(Break(brk));
+        self.items.push(Break(brk));
     }
 }

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -1,5 +1,6 @@
+mod display;
+
 use crate::{Break, Unparse};
-use std::fmt;
 
 #[derive(Debug, Default)]
 pub struct Stream(Vec<Item>);
@@ -34,11 +35,5 @@ impl Stream {
 
     pub(crate) fn add_break(&mut self, brk: Break) {
         self.0.push(Break(brk));
-    }
-}
-
-impl fmt::Display for Stream {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        todo!();
     }
 }

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -1,4 +1,5 @@
-use crate::Break;
+use crate::{Break, Unparse};
+use std::fmt;
 
 #[derive(Debug, Default)]
 pub struct Stream(Vec<Item>);
@@ -16,13 +17,15 @@ impl Stream {
         Self::default()
     }
 
-    pub fn write_str(&mut self, s: &str) {
-        self.0.push(Leaf(s.to_string()))
+    pub fn write<U>(&mut self, thing: &U)
+    where
+        U: Unparse,
+    {
+        thing.unparse_into(self)
     }
 
-    pub fn write_str_break(&mut self, s: &str, brk: Break) {
-        self.write_str(s);
-        self.add_break(brk);
+    pub fn write_string(&mut self, s: String) {
+        self.0.push(Leaf(s))
     }
 
     pub fn add_break(&mut self, brk: Break) {
@@ -31,5 +34,11 @@ impl Stream {
 
     pub fn add_substream(&mut self, sub: Stream) {
         self.0.push(Substream(sub));
+    }
+}
+
+impl fmt::Display for Stream {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        todo!();
     }
 }

--- a/unparse/src/stream.rs
+++ b/unparse/src/stream.rs
@@ -2,7 +2,7 @@ mod display;
 
 use crate::{Break, Unparse};
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Stream(Vec<Item>);
 
 #[derive(Debug)]
@@ -14,10 +14,6 @@ enum Item {
 use Item::*;
 
 impl Stream {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn write<U>(&mut self, thing: &U)
     where
         U: Unparse,
@@ -25,8 +21,17 @@ impl Stream {
         thing.unparse_into(self)
     }
 
-    pub fn add_substream(&mut self, sub: Stream) {
+    pub fn substream<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut Stream),
+    {
+        let mut sub = Stream::new();
+        f(&mut sub);
         self.0.push(Substream(sub));
+    }
+
+    pub(crate) fn new() -> Self {
+        Stream(vec![])
     }
 
     pub(crate) fn write_string(&mut self, s: String) {

--- a/unparse/src/stream/display.rs
+++ b/unparse/src/stream/display.rs
@@ -1,8 +1,30 @@
+use super::Item::{self, *};
 use crate::Stream;
 use std::fmt;
 
 impl fmt::Display for Stream {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        todo!();
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt_items(self, f, 0)
+    }
+}
+
+fn fmt_items(stream: &Stream, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
+    for item in &stream.0[..] {
+        fmt_item(item, f, depth)?;
+    }
+    Ok(())
+}
+
+fn fmt_item(item: &Item, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
+    match item {
+        Leaf(s) => f.write_str(&s),
+        Break(_) => {
+            f.write_str("\n")?;
+            for _ in 0..depth {
+                f.write_str("  ")?;
+            }
+            Ok(())
+        }
+        Substream(sub) => fmt_items(sub, f, depth + 1),
     }
 }

--- a/unparse/src/stream/display.rs
+++ b/unparse/src/stream/display.rs
@@ -4,20 +4,20 @@ use std::fmt;
 
 impl fmt::Display for Stream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt_items(self, f, 0)
+        fmt_stream(self, f)
     }
 }
 
-fn fmt_items(stream: &Stream, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
-    for item in &stream.0[..] {
-        fmt_item(item, f, depth)?;
+fn fmt_stream(stream: &Stream, f: &mut fmt::Formatter) -> fmt::Result {
+    for item in &stream.items[..] {
+        fmt_item(item, f, stream.depth)?;
     }
     Ok(())
 }
 
 fn fmt_item(item: &Item, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
     match item {
-        Leaf(s) => f.write_str(&s),
+        Leaf(s) => f.write_str(s),
         Break(_) => {
             f.write_str("\n")?;
             for _ in 0..depth {
@@ -25,6 +25,6 @@ fn fmt_item(item: &Item, f: &mut fmt::Formatter, depth: usize) -> fmt::Result {
             }
             Ok(())
         }
-        Substream(sub) => fmt_items(sub, f, depth + 1),
+        Substream(sub) => fmt_stream(sub, f),
     }
 }

--- a/unparse/src/stream/display.rs
+++ b/unparse/src/stream/display.rs
@@ -1,0 +1,8 @@
+use crate::Stream;
+use std::fmt;
+
+impl fmt::Display for Stream {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        todo!();
+    }
+}

--- a/unparse/src/unparse.rs
+++ b/unparse/src/unparse.rs
@@ -1,4 +1,4 @@
-use crate::Stream;
+use crate::{Break, Stream};
 
 pub trait Unparse {
     fn unparse(&self) -> Stream {
@@ -8,4 +8,22 @@ pub trait Unparse {
     }
 
     fn unparse_into(&self, s: &mut Stream);
+}
+
+impl<'a> Unparse for &'a str {
+    fn unparse_into(&self, s: &mut Stream) {
+        s.write_string(self.to_string())
+    }
+}
+
+impl Unparse for String {
+    fn unparse_into(&self, s: &mut Stream) {
+        s.write_string(self.clone())
+    }
+}
+
+impl Unparse for Break {
+    fn unparse_into(&self, s: &mut Stream) {
+        s.add_break(*self)
+    }
 }

--- a/unparse/src/unparse.rs
+++ b/unparse/src/unparse.rs
@@ -1,5 +1,11 @@
 use crate::Stream;
 
 pub trait Unparse {
-    fn unparse(&self) -> Stream;
+    fn unparse(&self) -> Stream {
+        let mut s = Stream::new();
+        self.unparse_into(&mut s);
+        s
+    }
+
+    fn unparse_into(&self, s: &mut Stream);
 }

--- a/unparse/src/unparse.rs
+++ b/unparse/src/unparse.rs
@@ -27,3 +27,12 @@ impl Unparse for Break {
         s.add_break(*self)
     }
 }
+
+impl<T> Unparse for Box<T>
+where
+    T: Unparse,
+{
+    fn unparse_into(&self, s: &mut Stream) {
+        s.write(self.as_ref())
+    }
+}

--- a/unparse/src/unparse.rs
+++ b/unparse/src/unparse.rs
@@ -1,0 +1,5 @@
+use crate::Stream;
+
+pub trait Unparse {
+    fn unparse(&self) -> Stream;
+}

--- a/value/src/func.rs
+++ b/value/src/func.rs
@@ -1,6 +1,6 @@
 use crate::{BindFailure, GenThunk, ScopeRef, ValRef};
 use sappho_east::{FuncClause, Pattern, PureEffects, PureExpr};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 #[derive(Debug)]
 pub struct Func {
@@ -26,10 +26,9 @@ impl Func {
 
 impl Unparse for Func {
     fn unparse_into(&self, s: &mut Stream) {
-        write!(f, "fn ")?;
-        self.binding.unparse(f, depth)?;
-        write!(f, " -> ")?;
-        self.body.unparse(f, depth)?;
-        Ok(())
+        s.write_str("fn ");
+        self.binding.unparse(s);
+        s.write_str(" -> ");
+        self.body.unparse(s);
     }
 }

--- a/value/src/func.rs
+++ b/value/src/func.rs
@@ -25,7 +25,7 @@ impl Func {
 }
 
 impl Unparse for Func {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         write!(f, "fn ")?;
         self.binding.unparse(f, depth)?;
         write!(f, " -> ")?;

--- a/value/src/func.rs
+++ b/value/src/func.rs
@@ -1,6 +1,6 @@
 use crate::{BindFailure, GenThunk, ScopeRef, ValRef};
 use sappho_east::{FuncClause, Pattern, PureEffects, PureExpr};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 #[derive(Debug)]
 pub struct Func {
@@ -24,12 +24,12 @@ impl Func {
     }
 }
 
-impl DisplayDepth for Func {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for Func {
+    fn unparse(&self) -> Stream {
         write!(f, "fn ")?;
-        self.binding.fmt_depth(f, depth)?;
+        self.binding.unparse(f, depth)?;
         write!(f, " -> ")?;
-        self.body.fmt_depth(f, depth)?;
+        self.body.unparse(f, depth)?;
         Ok(())
     }
 }

--- a/value/src/func.rs
+++ b/value/src/func.rs
@@ -26,9 +26,9 @@ impl Func {
 
 impl Unparse for Func {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write("fn ");
+        s.write(&"fn ");
         s.write(self.binding);
-        s.write(" -> ");
+        s.write(&" -> ");
         s.write(self.body);
     }
 }

--- a/value/src/func.rs
+++ b/value/src/func.rs
@@ -26,9 +26,9 @@ impl Func {
 
 impl Unparse for Func {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write_str("fn ");
-        self.binding.unparse(s);
-        s.write_str(" -> ");
-        self.body.unparse(s);
+        s.write("fn ");
+        s.write(self.binding);
+        s.write(" -> ");
+        s.write(self.body);
     }
 }

--- a/value/src/func.rs
+++ b/value/src/func.rs
@@ -27,8 +27,8 @@ impl Func {
 impl Unparse for Func {
     fn unparse_into(&self, s: &mut Stream) {
         s.write(&"fn ");
-        s.write(self.binding);
+        s.write(&self.binding);
         s.write(&" -> ");
-        s.write(self.body);
+        s.write(&self.body);
     }
 }

--- a/value/src/query.rs
+++ b/value/src/query.rs
@@ -24,6 +24,6 @@ impl Query {
 impl Unparse for Query {
     fn unparse_into(&self, s: &mut Stream) {
         s.write(&"query ");
-        s.write(self.body);
+        s.write(&self.body);
     }
 }

--- a/value/src/query.rs
+++ b/value/src/query.rs
@@ -23,7 +23,7 @@ impl Query {
 
 impl Unparse for Query {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write("query ");
+        s.write(&"query ");
         s.write(self.body);
     }
 }

--- a/value/src/query.rs
+++ b/value/src/query.rs
@@ -1,6 +1,6 @@
 use crate::{GenThunk, ScopeRef};
 use sappho_east::{QueryClause, QueryEffects, QueryExpr};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 
 #[derive(Debug)]
 pub struct Query {
@@ -23,8 +23,7 @@ impl Query {
 
 impl Unparse for Query {
     fn unparse_into(&self, s: &mut Stream) {
-        write!(f, "query ")?;
-        self.body.unparse(f, depth)?;
-        Ok(())
+        s.write_str("query ");
+        self.body.unparse_into(s);
     }
 }

--- a/value/src/query.rs
+++ b/value/src/query.rs
@@ -1,6 +1,6 @@
 use crate::{GenThunk, ScopeRef};
 use sappho_east::{QueryClause, QueryEffects, QueryExpr};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 
 #[derive(Debug)]
 pub struct Query {
@@ -21,10 +21,10 @@ impl Query {
     }
 }
 
-impl DisplayDepth for Query {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for Query {
+    fn unparse(&self) -> Stream {
         write!(f, "query ")?;
-        self.body.fmt_depth(f, depth)?;
+        self.body.unparse(f, depth)?;
         Ok(())
     }
 }

--- a/value/src/query.rs
+++ b/value/src/query.rs
@@ -22,7 +22,7 @@ impl Query {
 }
 
 impl Unparse for Query {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         write!(f, "query ")?;
         self.body.unparse(f, depth)?;
         Ok(())

--- a/value/src/query.rs
+++ b/value/src/query.rs
@@ -23,7 +23,7 @@ impl Query {
 
 impl Unparse for Query {
     fn unparse_into(&self, s: &mut Stream) {
-        s.write_str("query ");
-        self.body.unparse_into(s);
+        s.write("query ");
+        s.write(self.body);
     }
 }

--- a/value/src/valref.rs
+++ b/value/src/valref.rs
@@ -1,6 +1,6 @@
 use crate::{Coerce, CoercionFailure, Value};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 use std::borrow::Borrow;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -54,13 +54,13 @@ impl std::fmt::Display for ValRef {
 
 impl Unparse for ValRef {
     fn unparse_into(&self, s: &mut Stream) {
-        self.deref().unparse(f, depth)
+        self.deref().unparse(s)
     }
 }
 
 // Necessary for value as list form:
 impl<'a> Unparse for &'a ValRef {
     fn unparse_into(&self, s: &mut Stream) {
-        self.deref().unparse(f, depth)
+        self.deref().unparse(s)
     }
 }

--- a/value/src/valref.rs
+++ b/value/src/valref.rs
@@ -54,13 +54,13 @@ impl std::fmt::Display for ValRef {
 
 impl Unparse for ValRef {
     fn unparse_into(&self, s: &mut Stream) {
-        self.deref().unparse(s)
+        self.deref().unparse_into(s)
     }
 }
 
 // Necessary for value as list form:
 impl<'a> Unparse for &'a ValRef {
     fn unparse_into(&self, s: &mut Stream) {
-        self.deref().unparse(s)
+        self.deref().unparse_into(s)
     }
 }

--- a/value/src/valref.rs
+++ b/value/src/valref.rs
@@ -1,6 +1,6 @@
 use crate::{Coerce, CoercionFailure, Value};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 use std::borrow::Borrow;
 use std::ops::Deref;
 use std::rc::Rc;
@@ -48,19 +48,19 @@ impl TryIntoIdentMap<ValRef> for ValRef {
 
 impl std::fmt::Display for ValRef {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.fmt_depth(f, 0)
+        self.unparse(f, 0)
     }
 }
 
-impl DisplayDepth for ValRef {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.deref().fmt_depth(f, depth)
+impl Unparse for ValRef {
+    fn unparse(&self) -> Stream {
+        self.deref().unparse(f, depth)
     }
 }
 
 // Necessary for value as list form:
-impl<'a> DisplayDepth for &'a ValRef {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
-        self.deref().fmt_depth(f, depth)
+impl<'a> Unparse for &'a ValRef {
+    fn unparse(&self) -> Stream {
+        self.deref().unparse(f, depth)
     }
 }

--- a/value/src/valref.rs
+++ b/value/src/valref.rs
@@ -2,6 +2,7 @@ use crate::{Coerce, CoercionFailure, Value};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use sappho_unparse::{Stream, Unparse};
 use std::borrow::Borrow;
+use std::fmt;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -46,9 +47,9 @@ impl TryIntoIdentMap<ValRef> for ValRef {
     }
 }
 
-impl std::fmt::Display for ValRef {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        self.unparse(f, 0)
+impl fmt::Display for ValRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.unparse().fmt(f)
     }
 }
 

--- a/value/src/valref.rs
+++ b/value/src/valref.rs
@@ -53,14 +53,14 @@ impl std::fmt::Display for ValRef {
 }
 
 impl Unparse for ValRef {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.deref().unparse(f, depth)
     }
 }
 
 // Necessary for value as list form:
 impl<'a> Unparse for &'a ValRef {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         self.deref().unparse(f, depth)
     }
 }

--- a/value/src/value.rs
+++ b/value/src/value.rs
@@ -23,12 +23,12 @@ impl Unparse for Value {
         use Value::*;
 
         match self {
-            Num(x) => s.write_str(x.to_string()),
+            Num(x) => s.write(x.to_string()),
             Object(x) => {
                 if let Some(list) = x.try_into_identmap().and_then(|m| m.as_list_form()) {
-                    list.unparse(s)
+                    s.write(list)
                 } else {
-                    x.unparse(s)
+                    s.write(x)
                 }
             }
         }

--- a/value/src/value.rs
+++ b/value/src/value.rs
@@ -19,7 +19,7 @@ impl TryIntoIdentMap<ValRef> for Value {
 }
 
 impl Unparse for Value {
-    fn unparse(&self) -> Stream {
+    fn unparse_into(&self, s: &mut Stream) {
         use Value::*;
 
         match self {

--- a/value/src/value.rs
+++ b/value/src/value.rs
@@ -1,6 +1,6 @@
 use crate::{Object, ValRef};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{DisplayDepth, FmtResult, Formatter};
+use sappho_unparse::{Unparse, Stream};
 use std::fmt::Display;
 
 #[derive(Debug, derive_more::From)]
@@ -18,17 +18,17 @@ impl TryIntoIdentMap<ValRef> for Value {
     }
 }
 
-impl DisplayDepth for Value {
-    fn fmt_depth(&self, f: &mut Formatter, depth: usize) -> FmtResult {
+impl Unparse for Value {
+    fn unparse(&self) -> Stream {
         use Value::*;
 
         match self {
             Num(x) => x.fmt(f),
             Object(x) => {
                 if let Some(list) = x.try_into_identmap().and_then(|m| m.as_list_form()) {
-                    list.fmt_depth(f, depth)
+                    list.unparse(f, depth)
                 } else {
-                    x.fmt_depth(f, depth)
+                    x.unparse(f, depth)
                 }
             }
         }

--- a/value/src/value.rs
+++ b/value/src/value.rs
@@ -1,6 +1,6 @@
 use crate::{Object, ValRef};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
-use sappho_unparse::{Unparse, Stream};
+use sappho_unparse::{Stream, Unparse};
 use std::fmt::Display;
 
 #[derive(Debug, derive_more::From)]
@@ -23,12 +23,12 @@ impl Unparse for Value {
         use Value::*;
 
         match self {
-            Num(x) => x.fmt(f),
+            Num(x) => s.write_str(x.to_string()),
             Object(x) => {
                 if let Some(list) = x.try_into_identmap().and_then(|m| m.as_list_form()) {
-                    list.unparse(f, depth)
+                    list.unparse(s)
                 } else {
-                    x.unparse(f, depth)
+                    x.unparse(s)
                 }
             }
         }

--- a/value/src/value.rs
+++ b/value/src/value.rs
@@ -1,7 +1,6 @@
 use crate::{Object, ValRef};
 use sappho_identmap::{IdentMap, TryIntoIdentMap};
 use sappho_unparse::{Stream, Unparse};
-use std::fmt::Display;
 
 #[derive(Debug, derive_more::From)]
 pub enum Value {
@@ -23,10 +22,10 @@ impl Unparse for Value {
         use Value::*;
 
         match self {
-            Num(x) => s.write(x.to_string()),
+            Num(x) => s.write(&x.to_string()),
             Object(x) => {
                 if let Some(list) = x.try_into_identmap().and_then(|m| m.as_list_form()) {
-                    s.write(list)
+                    s.write(&list)
                 } else {
                     s.write(x)
                 }


### PR DESCRIPTION
Backwards compatible (in terms of tests) refactor away from `DisplayDepth` to `Unparse` trait which uses `Stream`. This creates an intermediate layer which we can use to make prettier text folding decisions during unparse `Display`.